### PR TITLE
Enable UseShellExecute to fix LaunchUriOrFileAction

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/Core/LaunchUriOrFileAction.cs
+++ b/src/Microsoft.Xaml.Behaviors/Core/LaunchUriOrFileAction.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Xaml.Behaviors.Core
             {
                 var processStartInfo = new ProcessStartInfo(this.Path)
                 {
-                    CreateNoWindow = true,
                     UseShellExecute = true
                 };
                 Process.Start(processStartInfo);

--- a/src/Microsoft.Xaml.Behaviors/Core/LaunchUriOrFileAction.cs
+++ b/src/Microsoft.Xaml.Behaviors/Core/LaunchUriOrFileAction.cs
@@ -35,7 +35,12 @@ namespace Microsoft.Xaml.Behaviors.Core
         {
             if (this.AssociatedObject != null && !string.IsNullOrEmpty(this.Path))
             {
-                Process.Start(this.Path);
+                var processStartInfo = new ProcessStartInfo(this.Path)
+                {
+                    CreateNoWindow = true,
+                    UseShellExecute = true
+                };
+                Process.Start(processStartInfo);
             }
         }
     }


### PR DESCRIPTION
Although dotnet core 3.0 is not supported, this change will at least solve #8 
I can image that there are cases where UseShellExecute doesn't make sense, with UWP this should be false.
But this library is only for .NET Framework and has a potential target in dotnet core 3.0, so from my point of view the fix doesn't to be more complex... just enable it!