### PR TITLE
A better dependency property cache

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/DataBindingHelper.cs
+++ b/src/Microsoft.Xaml.Behaviors/DataBindingHelper.cs
@@ -122,9 +122,9 @@ namespace Microsoft.Xaml.Behaviors
 
         private class CacheNode
         {
-            public DependencyProperty[] Properties;
+            public DependencyProperty[] Properties { get; set; }
 
-            public CacheNode Base;
+            public CacheNode Base { get; set; }
         }
     }
 }


### PR DESCRIPTION
The original cache uses a single array for every type, but it would waste memory because of duplicated dependency property objects of base classes.