### PR TITLE
Change XmlnsPrefix casing to lowercase.

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/AssemblyInfo.cs
+++ b/src/Microsoft.Xaml.Behaviors/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using Microsoft.Xaml.Behaviors;
 [assembly: SuppressMessage("Microsoft.Performance", "CA1824:MarkAssembliesWithNeutralResourcesLanguage")]
 [assembly: System.Resources.NeutralResourcesLanguage("en", System.Resources.UltimateResourceFallbackLocation.MainAssembly)]
 
-[assembly: XmlnsPrefix(@"http://schemas.microsoft.com/xaml/behaviors", "Interactions")]
+[assembly: XmlnsPrefix(@"http://schemas.microsoft.com/xaml/behaviors", "interactions")]
 [assembly: XmlnsDefinition(@"http://schemas.microsoft.com/xaml/behaviors", "Microsoft.Xaml.Behaviors")]
 [assembly: XmlnsDefinition(@"http://schemas.microsoft.com/xaml/behaviors", "Microsoft.Xaml.Behaviors.Core")]
 [assembly: XmlnsDefinition(@"http://schemas.microsoft.com/xaml/behaviors", "Microsoft.Xaml.Behaviors.Input")]


### PR DESCRIPTION
### Description of Change ###

Suggest to Change the XmlnsPrefix from *Interactions* to *interactions* since other libraries uses lower case to and ReSharper suggests me to change the casing to lowercase.

> Name 'Interactions' does not match rule 'Namespace alias'. Suggested name is 'interactions'.

- [ ] Has tests (if omitted, state reason in description) **no breaking change**
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
