### PR TITLE
Changes of visibility to get a better adaptation for extensions.

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/Behavior.cs
+++ b/src/Microsoft.Xaml.Behaviors/Behavior.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Xaml.Behaviors
         private Type associatedType;
         private DependencyObject associatedObject;
 
-        internal event EventHandler AssociatedObjectChanged;
+        public event EventHandler AssociatedObjectChanged;
 
         /// <summary>
         /// The type to which this behavior can be attached.

--- a/src/Microsoft.Xaml.Behaviors/NameResolver.cs
+++ b/src/Microsoft.Xaml.Behaviors/NameResolver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved. 
+﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 namespace Microsoft.Xaml.Behaviors
 {
@@ -11,7 +11,7 @@ namespace Microsoft.Xaml.Behaviors
     /// <summary>
     /// Provides data about which objects were affected when resolving a name change.
     /// </summary>
-    internal sealed class NameResolvedEventArgs : EventArgs
+    public sealed class NameResolvedEventArgs : EventArgs
     {
         private object oldObject;
         private object newObject;
@@ -37,7 +37,7 @@ namespace Microsoft.Xaml.Behaviors
     /// Helper class to handle the logic of resolving a TargetName into a Target element
     /// based on the context provided by a host element.
     /// </summary>
-    internal sealed class NameResolver
+    public sealed class NameResolver
     {
         private string name;
         private FrameworkElement nameScopeReferenceElement;

--- a/src/Microsoft.Xaml.Behaviors/TriggerBase.cs
+++ b/src/Microsoft.Xaml.Behaviors/TriggerBase.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Xaml.Behaviors
 
         public static readonly DependencyProperty ActionsProperty = ActionsPropertyKey.DependencyProperty;
 
-        internal TriggerBase(Type associatedObjectTypeConstraint)
+        public TriggerBase(Type associatedObjectTypeConstraint)
         {
             this.associatedObjectTypeConstraint = associatedObjectTypeConstraint;
             TriggerActionCollection newCollection = new TriggerActionCollection();


### PR DESCRIPTION
### Description of Change ###

Triggers only support events with the structure (object, EventArgs). I also like to use events with the structure (object DependencyPropertyCahngedEventArgs). Currently this is not possible. I can also imagine other connections to delegate, IObservable, Func<> or Action<>. To support more types, it would help to change some methods from internal to public. So you can create your own EventTriggerBase classes.

Examples are in my branch Behaviors.Extensions

### API Changes ###
Class Behavior 
Changed:
 - internal event EventHandler AssociatedObjectChanged => public event EventHandler AssociatedObjectChanged

Class NameResolver
 - internal sealed class NameResolver => public sealed class NameResolver
 - internal sealed class NameResolvedEventArgs : EventArgs => public sealed class NameResolvedEventArgs : EventArgs

Class TriggerBase
 - internal TriggerBase(Type associatedObjectTypeConstraint) => public TriggerBase(Type associatedObjectTypeConstraint)

### Behavioral Changes ###
Can create your own EventTriggerBase classes for other types of events in your own project. 
