### PR TITLE
Fix Extensibility assembly cause build error in Blend

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -79,19 +79,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Xaml.Behaviors.DesignTools\Microsoft.Xaml.Behaviors.DesignTools.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-    </ProjectReference>
-  </ItemGroup>
-
-  <ItemGroup Label="Package">
-    <None Include="bin\$(Configuration)\net45\Microsoft.Xaml.Behaviors.DesignTools.dll" PackagePath="lib\net45\Design" Pack="true" />
-    <None Include="bin\$(Configuration)\net45\Microsoft.Xaml.Behaviors.DesignTools.pdb" PackagePath="lib\net45\Design" Pack="true" />
-    <None Include="bin\$(Configuration)\net45\Microsoft.Xaml.Behaviors.DesignTools.dll" PackagePath="lib\netcoreapp3.0\Design" Pack="true" />
-    <None Include="bin\$(Configuration)\net45\Microsoft.Xaml.Behaviors.DesignTools.pdb" PackagePath="lib\netcoreapp3.0\Design" Pack="true" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="FinalPublicKey.snk" />
     <None Include="packages.config" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

*.DesignTools assembly reference was preventing building .NET WPF project in Blend.

### API Changes ###

None