### PR TITLE
Bug #55 Assembly version number incorrect.

### DIFF
--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
      <PackageReference Include="MSTest.TestAdapter">
       <Version>2.0.0</Version>
     </PackageReference>

--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -11,10 +11,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
      <PackageReference Include="MSTest.TestAdapter">
-      <Version>1.4.0</Version>
+      <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>1.4.0</Version>
+      <Version>2.0.0</Version>
     </PackageReference>
  </ItemGroup>
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/rel/v\\d+\\.\\d+" // we also release branches starting with vN.N


### PR DESCRIPTION
### Description of Change ###

* Updated version.json to use 1.1 version number. 
* Updated NuGet test framework references. 
* Removed NuGet package reference to Microsoft.NET.Test.Sdk, as it is preventing NuGet restore in pipeline.

### Bugs Fixed ###

[https://github.com/microsoft/XamlBehaviorsWpf/issues/55](https://github.com/microsoft/XamlBehaviorsWpf/issues/55)

### API Changes ###

None