### PR TITLE
Add rich property editors for design-time experience in WPF .NET Framework applications

### DIFF
--- a/src/BehaviorsSdk.sln
+++ b/src/BehaviorsSdk.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28407.52
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Behaviors", "Microsoft.Xaml.Behaviors\Microsoft.Xaml.Behaviors.csproj", "{8620C598-B704-429E-BCA5-7E5DDE506923}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Xaml.Behaviors", "Microsoft.Xaml.Behaviors\Microsoft.Xaml.Behaviors.csproj", "{8620C598-B704-429E-BCA5-7E5DDE506923}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "..\Test\UnitTests\UnitTests.csproj", "{76E3CE29-A9BC-4417-8224-CE18C6FE51B4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTests", "..\Test\UnitTests\UnitTests.csproj", "{76E3CE29-A9BC-4417-8224-CE18C6FE51B4}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DFFF3108-79F3-4D4C-BB7E-991E7B1B26A6}"
 	ProjectSection(SolutionItems) = preProject
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Behaviors.DesignTools", "Microsoft.Xaml.Behaviors.DesignTools\Microsoft.Xaml.Behaviors.DesignTools.csproj", "{6C3F3432-D090-450B-822B-95B7C3CEF663}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Behaviors.Design", "Microsoft.Xaml.Behaviors.Design\Microsoft.Xaml.Behaviors.Design.csproj", "{6FBA03AC-D43F-447F-A087-404B9DB14952}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,6 +39,10 @@ Global
 		{6C3F3432-D090-450B-822B-95B7C3CEF663}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6C3F3432-D090-450B-822B-95B7C3CEF663}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6C3F3432-D090-450B-822B-95B7C3CEF663}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FBA03AC-D43F-447F-A087-404B9DB14952}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FBA03AC-D43F-447F-A087-404B9DB14952}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FBA03AC-D43F-447F-A087-404B9DB14952}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FBA03AC-D43F-447F-A087-404B9DB14952}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BehaviorsSdk.sln
+++ b/src/BehaviorsSdk.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
 		..\Directory.Build.props = ..\Directory.Build.props
 		..\Directory.Build.targets = ..\Directory.Build.targets
+		tools\Install.ps1 = tools\Install.ps1
 		..\README.md = ..\README.md
 		..\version.json = ..\version.json
 	EndProjectSection

--- a/src/Microsoft.Xaml.Behaviors.Design/MetadataTableProvider.DesignerIsolation.cs
+++ b/src/Microsoft.Xaml.Behaviors.Design/MetadataTableProvider.DesignerIsolation.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System;
+using Microsoft.Xaml.Behaviors.Core;
+using Microsoft.Xaml.Behaviors.Input;
+using Microsoft.Xaml.Behaviors.Layout;
+using Microsoft.Xaml.Behaviors.Media;
+
+namespace Microsoft.Xaml.Behaviors.DesignTools
+{
+    partial class MetadataTableProvider
+    {
+        private void AddAttribute(Type type, Attribute attribute)
+        {
+            _attributeTableBuilder.AddCustomAttributes(type, attribute);
+        }
+
+        private void AddAttributes(Type type, params Attribute[] attributes)
+        {
+            foreach (Attribute attribute in attributes)
+            {
+                AddAttribute(type, attribute);
+            }
+        }
+
+        private void AddAttribute(Type type, string propertyName, Attribute attribute)
+        {
+            _attributeTableBuilder.AddCustomAttributes(type, propertyName, attribute);
+        }
+
+        private void AddAttributes(Type type, string propertyName, params Attribute[] attributes)
+        {
+            foreach (Attribute attribute in attributes)
+            {
+                AddAttribute(type, propertyName, attribute);
+            }
+        }
+
+        /// <summary>
+        /// This class contains the types used by the older Extensibility APIs.
+        /// </summary>
+        private static class Targets
+        {
+            internal static readonly Type EventTrigger = typeof(EventTrigger);
+            internal static readonly Type EventTriggerBase = typeof(EventTriggerBase);
+            internal static readonly Type TriggerBase = typeof(TriggerBase);
+            internal static readonly Type TriggerAction = typeof(TriggerAction);
+            internal static readonly Type TargetedTriggerAction = typeof(TargetedTriggerAction);
+            internal static readonly Type ChangePropertyAction = typeof(ChangePropertyAction);
+            internal static readonly Type InvokeCommandAction = typeof(InvokeCommandAction);
+            internal static readonly Type LaunchUriOrFileAction = typeof(LaunchUriOrFileAction);
+            internal static readonly Type MouseDragElementBehavior = typeof(MouseDragElementBehavior);
+            internal static readonly Type DataStateBehavior = typeof(DataStateBehavior);
+            internal static readonly Type FluidMoveBehavior = typeof(FluidMoveBehavior);
+            internal static readonly Type FluidMoveBehaviorBase = typeof(FluidMoveBehaviorBase);
+            internal static readonly Type StoryboardAction = typeof(StoryboardAction);
+            internal static readonly Type ControlStoryboardAction = typeof(ControlStoryboardAction);
+            internal static readonly Type GoToStateAction = typeof(GoToStateAction);
+            internal static readonly Type TranslateZoomRotateBehavior = typeof(TranslateZoomRotateBehavior);
+            internal static readonly Type PlaySoundAction = typeof(PlaySoundAction);
+            internal static readonly Type CallMethodAction = typeof(CallMethodAction);
+        }
+    }
+}

--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Debug\net45\Design\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;DesignerIsolation</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Release\net45\Design\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;DesignerIsolation</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -69,7 +69,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);DesignerIsolation</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Xaml.Behaviors.Design</RootNamespace>
     <AssemblyName>Microsoft.Xaml.Behaviors.Design</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Debug\net45\Design\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;DesignerIsolation</DefineConstants>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Release\net45\Design\</OutputPath>
-    <DefineConstants>TRACE;DesignerIsolation</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -69,4 +69,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);DesignerIsolation</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -4,17 +4,14 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6C3F3432-D090-450B-822B-95B7C3CEF663}</ProjectGuid>
+    <ProjectGuid>{6FBA03AC-D43F-447F-A087-404B9DB14952}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.Xaml.Behaviors.DesignTools</RootNamespace>
-    <AssemblyName>Microsoft.Xaml.Behaviors.DesignTools</AssemblyName>
+    <RootNamespace>Microsoft.Xaml.Behaviors.Design</RootNamespace>
+    <AssemblyName>Microsoft.Xaml.Behaviors.Design</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,37 +31,46 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.DesignTools.Extensibility, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
-    <Reference Include="Microsoft.VisualStudio.DesignTools.Interaction, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
+    <Reference Include="Microsoft.Windows.Design.Extensibility, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
+    <Reference Include="Microsoft.Windows.Design.Interaction, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MetadataTableProvider.cs" />
-    <Compile Include="MetadataTableProvider.SurfaceIsolation.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
+    <Compile Include="..\Microsoft.Xaml.Behaviors.DesignTools\MetadataTableProvider.cs">
+      <Link>MetadataTableProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.Xaml.Behaviors.DesignTools\Properties\Resources.Designer.cs">
+      <Link>Resources.Designer.cs</Link>
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="MetadataTableProvider.DesignerIsolation.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Properties\Resources.resx">
+    <EmbeddedResource Include="..\Microsoft.Xaml.Behaviors.DesignTools\Properties\Resources.resx">
+      <Link>Resources.resx</Link>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
+      <CustomToolNamespace>Microsoft.Xaml.Behaviors.DesignTools</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Xaml.Behaviors\Microsoft.Xaml.Behaviors.csproj">
+      <Project>{8620c598-b704-429e-bca5-7e5dde506923}</Project>
+      <Name>Microsoft.Xaml.Behaviors</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);DesignerIsolation</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Xaml.Behaviors.Design</RootNamespace>
     <AssemblyName>Microsoft.Xaml.Behaviors.Design</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -46,13 +47,12 @@
     <Compile Include="..\Microsoft.Xaml.Behaviors.DesignTools\MetadataTableProvider.cs">
       <Link>MetadataTableProvider.cs</Link>
     </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
     <Compile Include="MetadataTableProvider.DesignerIsolation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Microsoft.Xaml.Behaviors.DesignTools\Properties\Resources.resx">

--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -46,8 +46,7 @@
     <Compile Include="..\Microsoft.Xaml.Behaviors.DesignTools\MetadataTableProvider.cs">
       <Link>MetadataTableProvider.cs</Link>
     </Compile>
-    <Compile Include="..\Microsoft.Xaml.Behaviors.DesignTools\Properties\Resources.Designer.cs">
-      <Link>Resources.Designer.cs</Link>
+    <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
@@ -57,10 +56,10 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Microsoft.Xaml.Behaviors.DesignTools\Properties\Resources.resx">
-      <Link>Resources.resx</Link>
+      <Link>Properties\Resources.resx</Link>
       <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <CustomToolNamespace>Microsoft.Xaml.Behaviors.DesignTools</CustomToolNamespace>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Xaml.Behaviors.Design/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Xaml.Behaviors.Design/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.Xaml.Behaviors.Design")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.Xaml.Behaviors.Design")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6fba03ac-d43f-447f-a087-404b9db14952")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Microsoft.Xaml.Behaviors.Design/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Xaml.Behaviors.Design/Properties/AssemblyInfo.cs
@@ -19,9 +19,6 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("6fba03ac-d43f-447f-a087-404b9db14952")]
-
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version

--- a/src/Microsoft.Xaml.Behaviors.Design/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Xaml.Behaviors.Design/Properties/Resources.Designer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Xaml.Behaviors.DesignTools {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Xaml.Behaviors.DesignTools.Properties.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Xaml.Behaviors.Design.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/Microsoft.Xaml.Behaviors.DesignTools/MetadataTableProvider.SurfaceIsolation.cs
+++ b/src/Microsoft.Xaml.Behaviors.DesignTools/MetadataTableProvider.SurfaceIsolation.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System;
+
+namespace Microsoft.Xaml.Behaviors.DesignTools
+{
+    partial class MetadataTableProvider
+    {
+        private void AddAttributes(string typeIdentifier, params Attribute[] attributes)
+        {
+            _attributeTableBuilder.AddCustomAttributes(typeIdentifier, attributes);
+        }
+
+        private void AddAttributes(string typeIdentifier, string propertyName, params Attribute[] attributes)
+        {
+            _attributeTableBuilder.AddCustomAttributes(typeIdentifier, propertyName, attributes);
+        }
+
+        /// <summary>
+        /// This class contains the type names required by the new Extensibility APIs.
+        /// </summary>
+        private static class Targets
+        {
+            internal const string EventTrigger = "Microsoft.Xaml.Behaviors.EventTrigger";
+            internal const string EventTriggerBase = "Microsoft.Xaml.Behaviors.EventTriggerBase";
+            internal const string TriggerBase = "Microsoft.Xaml.Behaviors.TriggerBase";
+            internal const string TriggerAction = "Microsoft.Xaml.Behaviors.TriggerAction";
+            internal const string TargetedTriggerAction = "Microsoft.Xaml.Behaviors.TargetedTriggerAction";
+            internal const string ChangePropertyAction = "Microsoft.Xaml.Behaviors.Core.ChangePropertyAction";
+            internal const string InvokeCommandAction = "Microsoft.Xaml.Behaviors.InvokeCommandAction";
+            internal const string LaunchUriOrFileAction = "Microsoft.Xaml.Behaviors.Core.LaunchUriOrFileAction";
+            internal const string MouseDragElementBehavior = "Microsoft.Xaml.Behaviors.Layout.MouseDragElementBehavior";
+            internal const string DataStateBehavior = "Microsoft.Xaml.Behaviors.Core.DataStateBehavior";
+            internal const string FluidMoveBehavior = "Microsoft.Xaml.Behaviors.Layout.FluidMoveBehavior";
+            internal const string FluidMoveBehaviorBase = "Microsoft.Xaml.Behaviors.Layout.FluidMoveBehaviorBase";
+            internal const string StoryboardAction = "Microsoft.Xaml.Behaviors.Media.StoryboardAction";
+            internal const string ControlStoryboardAction = "Microsoft.Xaml.Behaviors.Media.ControlStoryboardAction";
+            internal const string GoToStateAction = "Microsoft.Xaml.Behaviors.Core.GoToStateAction";
+            internal const string TranslateZoomRotateBehavior = "Microsoft.Xaml.Behaviors.Input.TranslateZoomRotateBehavior";
+            internal const string PlaySoundAction = "Microsoft.Xaml.Behaviors.Media.PlaySoundAction";
+            internal const string CallMethodAction = "Microsoft.Xaml.Behaviors.Core.CallMethodAction";
+        }
+    }
+}

--- a/src/Microsoft.Xaml.Behaviors.DesignTools/MetadataTableProvider.cs
+++ b/src/Microsoft.Xaml.Behaviors.DesignTools/MetadataTableProvider.cs
@@ -1,17 +1,23 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
+using System;
+using System.ComponentModel;
+
+#if DesignerIsolation
+using Microsoft.Windows.Design.Metadata;
+using Microsoft.Windows.Design.PropertyEditing;
+using Editors = Microsoft.Windows.Design.PropertyEditing.Editors;
+#else
 using Microsoft.VisualStudio.DesignTools.Extensibility.Metadata;
 using Microsoft.VisualStudio.DesignTools.Extensibility.PropertyEditing;
 using Editors = Microsoft.VisualStudio.DesignTools.Extensibility.PropertyEditing.Editors;
-using Microsoft.Xaml.Behaviors.DesignTools.Properties;
-using System;
-using System.ComponentModel;
+#endif
 
 [assembly: ProvideMetadata(typeof(Microsoft.Xaml.Behaviors.DesignTools.MetadataTableProvider))]
 namespace Microsoft.Xaml.Behaviors.DesignTools
 {
-    internal class MetadataTableProvider : IProvideAttributeTable
+    internal partial class MetadataTableProvider : IProvideAttributeTable
     {
         private AttributeTableBuilder _attributeTableBuilder;
 
@@ -26,25 +32,24 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                 }
 
                 #region EventTrigger
-                AddAttributes("Microsoft.Xaml.Behaviors.EventTrigger",
+                AddAttributes(Targets.EventTrigger,// "Microsoft.Xaml.Behaviors.EventTrigger",
                     new DescriptionAttribute(Resources.Description_EventTriggerBehavior));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.EventTrigger", "EventName",
+                AddAttributes(Targets.EventTrigger, "EventName",
                     new DescriptionAttribute(Resources.Description_EventTriggerBehavior_EventName),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     PropertyValueEditor.CreateEditorAttribute(typeof(Editors.EventPickerPropertyValueEditor)));
                 #endregion EventTrigger
 
                 #region EventTriggerBase
-                AddAttributes("Microsoft.Xaml.Behaviors.EventTriggerBase",
-                    new DefaultBindingPropertyAttribute("SourceObject"));
+                AddAttributes(Targets.EventTriggerBase, new DefaultBindingPropertyAttribute("SourceObject"));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.EventTriggerBase", "SourceObject",
+                AddAttributes(Targets.EventTriggerBase, "SourceObject",
                     new PropertyOrderAttribute(PropertyOrder.CreateBefore(PropertyOrder.Early)),
                     new DescriptionAttribute(Resources.Description_EventTriggerBase_SourceObject),
                     PropertyValueEditor.CreateEditorAttribute(typeof(Editors.ElementBindingPickerPropertyValueEditor)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.EventTriggerBase", "SourceName",
+                AddAttributes(Targets.EventTriggerBase, "SourceName",
                     new PropertyOrderAttribute(PropertyOrder.CreateBefore(PropertyOrder.Early)),
                     new DescriptionAttribute(Resources.Description_EventTriggerBase_SourceName),
                     // This is mapped to BehaviorElementPickerPropertyValueEditor in legacy.
@@ -52,28 +57,26 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                 #endregion EventTriggerBase
 
                 #region TriggerBase
-                AddAttributes("Microsoft.Xaml.Behaviors.TriggerBase", "Actions",
-                    new BrowsableAttribute(false));
+                AddAttributes(Targets.TriggerBase, "Actions", new BrowsableAttribute(false));
                 #endregion TriggerBase
 
                 #region TriggerAction
-                AddAttributes("Microsoft.Xaml.Behaviors.TriggerAction", "IsEnabled",
+                AddAttributes(Targets.TriggerAction, "IsEnabled",
                     new DescriptionAttribute(Resources.Description_TriggerAction_IsEnabled),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
                 #endregion TriggerAction
 
                 #region TargetedTriggerAction
-                AddAttributes("Microsoft.Xaml.Behaviors.TargetedTriggerAction",
-                    new DefaultBindingPropertyAttribute("TargetObject"));
+                AddAttributes(Targets.TargetedTriggerAction, new DefaultBindingPropertyAttribute("TargetObject"));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.TargetedTriggerAction", "TargetObject",
+                AddAttributes(Targets.TargetedTriggerAction, "TargetObject",
                     new PropertyOrderAttribute(PropertyOrder.CreateBefore(PropertyOrder.Early)),
                     new DescriptionAttribute(Resources.Description_TargetedTriggerAction_TargetObject),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     PropertyValueEditor.CreateEditorAttribute(typeof(Editors.ElementBindingPickerPropertyValueEditor)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.TargetedTriggerAction", "TargetName",
+                AddAttributes(Targets.TargetedTriggerAction, "TargetName",
                     new PropertyOrderAttribute(PropertyOrder.CreateBefore(PropertyOrder.Early)),
                     new DescriptionAttribute(Resources.Description_TargetedTriggerAction_TargetName),
                     new CategoryAttribute(Resources.Category_Common_Properties),
@@ -82,159 +85,158 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                 #endregion TargetedTriggerAction
 
                 #region ChangePropertyAction
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.ChangePropertyAction", 
-                    new DescriptionAttribute(Resources.Description_ChangePropertyAction));
+                AddAttributes(Targets.ChangePropertyAction, new DescriptionAttribute(Resources.Description_ChangePropertyAction));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.ChangePropertyAction", "PropertyName",
+                AddAttributes(Targets.ChangePropertyAction, "PropertyName",
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new DescriptionAttribute(Resources.Description_ChangePropertyAction_PropertyName),
                     PropertyValueEditor.CreateEditorAttribute(typeof(Editors.PropertyPickerPropertyValueEditor)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.ChangePropertyAction", "Duration",
+                AddAttributes(Targets.ChangePropertyAction, "Duration",
                     new CategoryAttribute(Resources.Category_Animation_Properties),
                     new DescriptionAttribute(Resources.Description_ChangePropertyAction_Duration));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.ChangePropertyAction", "Increment",
+                AddAttributes(Targets.ChangePropertyAction, "Increment",
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new DescriptionAttribute(Resources.Description_ChangePropertyAction_Increment));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.ChangePropertyAction", "Value", 
+                AddAttributes(Targets.ChangePropertyAction, "Value", 
                     new DescriptionAttribute(Resources.Description_ChangePropertyAction_Value), 
                     new CategoryAttribute(Resources.Category_Common_Properties));
                 #endregion ChangePropertyAction
 
                 #region InvokeCommandAction
-                AddAttributes("Microsoft.Xaml.Behaviors.InvokeCommandAction",
+                AddAttributes(Targets.InvokeCommandAction,
                     new DescriptionAttribute(Resources.Description_InvokeCommandAction),
                     new DefaultBindingPropertyAttribute("Command"));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.InvokeCommandAction", "Command",
+                AddAttributes(Targets.InvokeCommandAction, "Command",
                     new DescriptionAttribute(Resources.Description_InvokeCommandAction_Command),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     PropertyValueEditor.CreateEditorAttribute(typeof(Editors.PropertyBindingPickerPropertyValueEditor)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.InvokeCommandAction", "CommandParameter",
+                AddAttributes(Targets.InvokeCommandAction, "CommandParameter",
                     new TypeConverterAttribute(typeof(StringConverter)),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new DescriptionAttribute(Resources.Description_InvokeCommandAction_Command),
                     new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.InvokeCommandAction", "CommandName",
+                AddAttributes(Targets.InvokeCommandAction, "CommandName",
                     new DescriptionAttribute(Resources.Description_InvokeCommandAction_CommandName),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
                 #endregion InvokeCommandAction
 
                 #region InvokeCommandAction
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.LaunchUriOrFileAction",
+                AddAttributes(Targets.LaunchUriOrFileAction,
                     new DescriptionAttribute(Resources.Description_LaunchURLOrFileAction));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.LaunchUriOrFileAction", "Path",
+                AddAttributes(Targets.LaunchUriOrFileAction, "Path",
                     new DescriptionAttribute(Resources.Description_LaunchURLOrFileAction_Path),
                     new CategoryAttribute(Resources.Category_Common_Properties));
                 #endregion InvokeCommandAction
 
                 #region MouseDragElementBehavior
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.MouseDragElementBehavior",
+                AddAttributes(Targets.MouseDragElementBehavior,
                     new DescriptionAttribute(Resources.Description_MouseDragElementBehavior));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.MouseDragElementBehavior", "X",
+                AddAttributes(Targets.MouseDragElementBehavior, "X",
                     new CanBeEmptyAttribute(true),
                     new DescriptionAttribute(Resources.Description_MouseDragElementBehavior_X),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.MouseDragElementBehavior", "Y",
+                AddAttributes(Targets.MouseDragElementBehavior, "Y",
                     new CanBeEmptyAttribute(true),
                     new DescriptionAttribute(Resources.Description_MouseDragElementBehavior_Y),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.MouseDragElementBehavior", "ConstrainToParentBounds",
+                AddAttributes(Targets.MouseDragElementBehavior, "ConstrainToParentBounds",
                     new DescriptionAttribute(Resources.Description_MouseDragElementBehavior_ConstrainToParentBounds),
                     new CategoryAttribute(Resources.Category_Common_Properties));
                 #endregion MouseDragElementBehavior
 
                 #region DataStateBehavior
                 PropertyOrder order = PropertyOrder.Default;
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.DataStateBehavior",
+                AddAttributes(Targets.DataStateBehavior,
                     new DescriptionAttribute(Resources.Description_DataStateBehavior),
                     new DefaultBindingPropertyAttribute("Binding"));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.DataStateBehavior", "Binding",
+                AddAttributes(Targets.DataStateBehavior, "Binding",
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
                     new DescriptionAttribute(Resources.Description_DataStateBehavior_Binding),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     PropertyValueEditor.CreateEditorAttribute(typeof(Editors.PropertyBindingPickerPropertyValueEditor)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.DataStateBehavior", "Value",
+                AddAttributes(Targets.DataStateBehavior, "Value",
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
                     new DescriptionAttribute(Resources.Description_DataStateBehavior_Value),
                     new TypeConverterAttribute(typeof(StringConverter)),
                     new CategoryAttribute(Resources.Category_Common_Properties));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.DataStateBehavior", "TrueState",
+                AddAttributes(Targets.DataStateBehavior, "TrueState",
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
                     new DescriptionAttribute(Resources.Description_DataStateBehavior_TrueState),
                     new CategoryAttribute(Resources.Category_Common_Properties));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.DataStateBehavior", "FalseState",
+                AddAttributes(Targets.DataStateBehavior, "FalseState",
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
                     new DescriptionAttribute(Resources.Description_DataStateBehavior_FalseState),
                     new CategoryAttribute(Resources.Category_Common_Properties));
                 #endregion DataStateBehavior
 
                 #region FluidMoveBehavior
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehavior",
+                AddAttributes(Targets.FluidMoveBehavior,
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehavior", "Duration",
+                AddAttributes(Targets.FluidMoveBehavior, "Duration",
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior_Duration),
                     new CategoryAttribute(Resources.Category_Animation_Properties));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehavior", "InitialTag",
+                AddAttributes(Targets.FluidMoveBehavior, "InitialTag",
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior_InitialTag),
                     new CategoryAttribute(Resources.Category_Tag_Properties));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehavior", "InitialTagPath",
+                AddAttributes(Targets.FluidMoveBehavior, "InitialTagPath",
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior_InitialTagPath),
                     new CategoryAttribute(Resources.Category_Tag_Properties));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehavior", "FloatAbove",
+                AddAttributes(Targets.FluidMoveBehavior, "FloatAbove",
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior_FloatAbove),
                     new CategoryAttribute(Resources.Category_Animation_Properties));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehavior", "EaseX",
+                AddAttributes(Targets.FluidMoveBehavior, "EaseX",
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior_EaseX),
                     new CategoryAttribute(Resources.Category_Animation_Properties));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehavior", "EaseY",
+                AddAttributes(Targets.FluidMoveBehavior, "EaseY",
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior_EaseY),
                     new CategoryAttribute(Resources.Category_Animation_Properties));
                 #endregion FluidMoveBehavior
 
                 #region FluidMoveBehaviorBase
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehaviorBase", "AppliesTo",
+                AddAttributes(Targets.FluidMoveBehaviorBase, "AppliesTo",
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior_AppliesTo),
                     new CategoryAttribute(Resources.Category_Common_Properties));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehaviorBase", "IsActive",
+                AddAttributes(Targets.FluidMoveBehaviorBase, "IsActive",
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior_IsActive),
                     new EditorBrowsableAttribute(EditorBrowsableState.Advanced),
                     new CategoryAttribute(Resources.Category_Common_Properties));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehaviorBase", "Tag",
+                AddAttributes(Targets.FluidMoveBehaviorBase, "Tag",
                     new DescriptionAttribute(Resources.Description_FluidMoveSetTagBehavior_Tag),
                     new CategoryAttribute(Resources.Category_Tag_Properties));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Layout.FluidMoveBehaviorBase", "TagPath",
+                AddAttributes(Targets.FluidMoveBehaviorBase, "TagPath",
                     new DescriptionAttribute(Resources.Description_FluidMoveSetTagBehavior_TagPath),
                     new EditorBrowsableAttribute(EditorBrowsableState.Advanced),
                     new CategoryAttribute(Resources.Category_Tag_Properties));
                 #endregion FluidMoveBehaviorBase
 
                 #region StoryboardAction
-                AddAttributes("Microsoft.Xaml.Behaviors.Media.StoryboardAction", "Storyboard",
+                AddAttributes(Targets.StoryboardAction, "Storyboard",
                     new DescriptionAttribute(Resources.Description_ControlStoryboardAction_Storyboard),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new TypeConverterAttribute(typeof(TypeConverter)),
@@ -242,81 +244,81 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                 #endregion StoryboardAction
 
                 #region ControlStoryboardAction
-                AddAttributes("Microsoft.Xaml.Behaviors.Media.ControlStoryboardAction", 
+                AddAttributes(Targets.ControlStoryboardAction, 
                     new DescriptionAttribute(Resources.Description_ControlStoryboardAction));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Media.ControlStoryboardAction", "ControlStoryboardOption",
+                AddAttributes(Targets.ControlStoryboardAction, "ControlStoryboardOption",
                     new DescriptionAttribute(Resources.Description_ControlStoryboardAction_ControlStoryboardOption),
                     new CategoryAttribute(Resources.Category_Common_Properties));
                 #endregion ControlStoryboardAction
 
                 #region GotoStateAction
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.GotoStateAction",
+                AddAttributes(Targets.GoToStateAction,
                     new DescriptionAttribute(Resources.Description_GoToStateAction));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.GotoStateAction", "StateName",
+                AddAttributes(Targets.GoToStateAction, "StateName",
                     new DescriptionAttribute(Resources.Description_GoToStateAction_StateName),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     PropertyValueEditor.CreateEditorAttribute(typeof(Editors.StatePickerPropertyValueEditor)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.GotoStateAction", "UseTransitions",
+                AddAttributes(Targets.GoToStateAction, "UseTransitions",
                     new DescriptionAttribute(Resources.Description_GoToStateAction_UseTransitions),
                     new CategoryAttribute(Resources.Category_Common_Properties));
                 #endregion GotoStateAction
 
                 #region TranslateZoomRotateBehavior
-                AddAttributes("Microsoft.Xaml.Behaviors.Input.TranslateZoomRotateBehavior",
+                AddAttributes(Targets.TranslateZoomRotateBehavior,
                     new DescriptionAttribute(Resources.Description_TranslateZoomRotateBehavior));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Input.TranslateZoomRotateBehavior", "RotationalFriction",
+                AddAttributes(Targets.TranslateZoomRotateBehavior, "RotationalFriction",
                     new DescriptionAttribute(Resources.Description_TranslateZoomRotateBehavior_RotationalFriction),
                     new NumberIncrementsAttribute(0.001, 0.01, 0.1),
                     new NumberRangesAttribute(0, 0, 1, 1, false),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Input.TranslateZoomRotateBehavior", "TranslateFriction",
+                AddAttributes(Targets.TranslateZoomRotateBehavior, "TranslateFriction",
                     new DescriptionAttribute(Resources.Description_TranslateZoomRotateBehavior_TranslateFriction),
                     new NumberIncrementsAttribute(0.001, 0.01, 0.1),
                     new NumberRangesAttribute(0, 0, 1, 1, false),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Input.TranslateZoomRotateBehavior", "MinimumScale",
+                AddAttributes(Targets.TranslateZoomRotateBehavior, "MinimumScale",
                     new DescriptionAttribute(Resources.Description_TranslateZoomRotateBehavior_MinimumScale),
                     new NumberIncrementsAttribute(0.01, 0.1, 1.0),
                     new NumberRangesAttribute(0, 0, null, null, false),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Input.TranslateZoomRotateBehavior", "MaximumScale",
+                AddAttributes(Targets.TranslateZoomRotateBehavior, "MaximumScale",
                     new DescriptionAttribute(Resources.Description_TranslateZoomRotateBehavior_MaximumScale),
                     new NumberIncrementsAttribute(0.01, 0.1, 1.0),
                     new NumberRangesAttribute(0, 0, null, null, false),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Input.TranslateZoomRotateBehavior", "SupportedGestures",
+                AddAttributes(Targets.TranslateZoomRotateBehavior, "SupportedGestures",
                     new DescriptionAttribute(Resources.Description_TranslateZoomRotateBehavior_SupportedGestures),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Input.TranslateZoomRotateBehavior", "ConstrainToParentBounds",
+                AddAttributes(Targets.TranslateZoomRotateBehavior, "ConstrainToParentBounds",
                     new DescriptionAttribute(Resources.Description_TranslateZoomRotateBehavior_ConstrainToParentBounds),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)));
                 #endregion TranslateZoomRotateBehavior
 
                 #region PlaySoundAction
-                AddAttributes("Microsoft.Xaml.Behaviors.Media.PlaySoundAction",
+                AddAttributes(Targets.PlaySoundAction,
                     new DescriptionAttribute(Resources.Description_PlaySoundAction));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Media.PlaySoundAction", "Source",
+                AddAttributes(Targets.PlaySoundAction, "Source",
                     new DescriptionAttribute(Resources.Description_PlaySoundAction_Source),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     PropertyValueEditor.CreateEditorAttribute(typeof(Editors.UriPropertyValueEditor)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Media.PlaySoundAction", "Volume",
+                AddAttributes(Targets.PlaySoundAction, "Volume",
                     new NumberRangesAttribute(0, 0, 1, 1, false),
                     new NumberIncrementsAttribute(0.001, 0.01, 0.1),
                     new DescriptionAttribute(Resources.Description_PlaySoundAction_Volume),
@@ -324,17 +326,17 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                 #endregion PlaySoundAction
 
                 #region CallMethodAction
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.CallMethodAction",
+                AddAttributes(Targets.CallMethodAction,
                     new DescriptionAttribute(Resources.Description_CallMethodAction),
                     new DefaultBindingPropertyAttribute("TargetObject"));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.CallMethodAction", "TargetObject",
+                AddAttributes(Targets.CallMethodAction, "TargetObject",
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
                     new DescriptionAttribute(Resources.Description_CallMethodAction_TargetObject),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     PropertyValueEditor.CreateEditorAttribute(typeof(Editors.ElementBindingPickerPropertyValueEditor)));
 
-                AddAttributes("Microsoft.Xaml.Behaviors.Core.CallMethodAction", "MethodName",
+                AddAttributes(Targets.CallMethodAction, "MethodName",
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
                     new DescriptionAttribute(Resources.Description_CallMethodAction_MethodName),
                     new CategoryAttribute(Resources.Category_Common_Properties));
@@ -342,16 +344,6 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
 
                 return _attributeTableBuilder.CreateTable();
             }
-        }
-        
-        private void AddAttributes(string typeIdentifier, params Attribute[] attributes)
-        {
-            _attributeTableBuilder.AddCustomAttributes(typeIdentifier, attributes);
-        }
-
-        private void AddAttributes(string typeIdentifier, string propertyName, params Attribute[] attributes)
-        {
-            _attributeTableBuilder.AddCustomAttributes(typeIdentifier, propertyName, attributes);
         }
     }
 }

--- a/src/Microsoft.Xaml.Behaviors.DesignTools/MetadataTableProvider.cs
+++ b/src/Microsoft.Xaml.Behaviors.DesignTools/MetadataTableProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
-using System;
 using System.ComponentModel;
 
 #if DesignerIsolation
@@ -30,9 +29,9 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                 {
                     _attributeTableBuilder = new AttributeTableBuilder();
                 }
-
+                
                 #region EventTrigger
-                AddAttributes(Targets.EventTrigger,// "Microsoft.Xaml.Behaviors.EventTrigger",
+                AddAttributes(Targets.EventTrigger,
                     new DescriptionAttribute(Resources.Description_EventTriggerBehavior));
 
                 AddAttributes(Targets.EventTrigger, "EventName",
@@ -55,7 +54,7 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                     // This is mapped to BehaviorElementPickerPropertyValueEditor in legacy.
                     PropertyValueEditor.CreateEditorAttribute(typeof(Editors.PropertyPickerPropertyValueEditor)));
                 #endregion EventTriggerBase
-
+                
                 #region TriggerBase
                 AddAttributes(Targets.TriggerBase, "Actions", new BrowsableAttribute(false));
                 #endregion TriggerBase
@@ -95,7 +94,7 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                 AddAttributes(Targets.ChangePropertyAction, "Duration",
                     new CategoryAttribute(Resources.Category_Animation_Properties),
                     new DescriptionAttribute(Resources.Description_ChangePropertyAction_Duration));
-
+                
                 AddAttributes(Targets.ChangePropertyAction, "Increment",
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new DescriptionAttribute(Resources.Description_ChangePropertyAction_Increment));
@@ -130,7 +129,7 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                 #region InvokeCommandAction
                 AddAttributes(Targets.LaunchUriOrFileAction,
                     new DescriptionAttribute(Resources.Description_LaunchURLOrFileAction));
-
+                
                 AddAttributes(Targets.LaunchUriOrFileAction, "Path",
                     new DescriptionAttribute(Resources.Description_LaunchURLOrFileAction_Path),
                     new CategoryAttribute(Resources.Category_Common_Properties));
@@ -162,7 +161,7 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                 AddAttributes(Targets.DataStateBehavior,
                     new DescriptionAttribute(Resources.Description_DataStateBehavior),
                     new DefaultBindingPropertyAttribute("Binding"));
-
+                
                 AddAttributes(Targets.DataStateBehavior, "Binding",
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
                     new DescriptionAttribute(Resources.Description_DataStateBehavior_Binding),
@@ -205,7 +204,7 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                 AddAttributes(Targets.FluidMoveBehavior, "FloatAbove",
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior_FloatAbove),
                     new CategoryAttribute(Resources.Category_Animation_Properties));
-
+                
                 AddAttributes(Targets.FluidMoveBehavior, "EaseX",
                     new DescriptionAttribute(Resources.Description_FluidMoveBehavior_EaseX),
                     new CategoryAttribute(Resources.Category_Animation_Properties));
@@ -251,7 +250,7 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                     new DescriptionAttribute(Resources.Description_ControlStoryboardAction_ControlStoryboardOption),
                     new CategoryAttribute(Resources.Category_Common_Properties));
                 #endregion ControlStoryboardAction
-
+                
                 #region GotoStateAction
                 AddAttributes(Targets.GoToStateAction,
                     new DescriptionAttribute(Resources.Description_GoToStateAction));
@@ -290,7 +289,7 @@ namespace Microsoft.Xaml.Behaviors.DesignTools
                     new NumberRangesAttribute(0, 0, null, null, false),
                     new CategoryAttribute(Resources.Category_Common_Properties),
                     new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)));
-
+                
                 AddAttributes(Targets.TranslateZoomRotateBehavior, "MaximumScale",
                     new DescriptionAttribute(Resources.Description_TranslateZoomRotateBehavior_MaximumScale),
                     new NumberIncrementsAttribute(0.01, 0.1, 1.0),

--- a/src/Microsoft.Xaml.Behaviors.DesignTools/Microsoft.Xaml.Behaviors.DesignTools.csproj
+++ b/src/Microsoft.Xaml.Behaviors.DesignTools/Microsoft.Xaml.Behaviors.DesignTools.csproj
@@ -36,8 +36,6 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.DesignTools.Extensibility, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
     <Reference Include="Microsoft.VisualStudio.DesignTools.Interaction, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xaml" />
@@ -64,6 +62,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
+      <CustomToolNamespace>Microsoft.Xaml.Behaviors.DesignTools</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Microsoft.Xaml.Behaviors.DesignTools/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Xaml.Behaviors.DesignTools/Properties/Resources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.Xaml.Behaviors.DesignTools.Properties {
+namespace Microsoft.Xaml.Behaviors.DesignTools {
     using System;
     
     
@@ -39,7 +39,7 @@ namespace Microsoft.Xaml.Behaviors.DesignTools.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Xaml.Behaviors.DesignTools.Properties.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Xaml.Behaviors.Design.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/Microsoft.Xaml.Behaviors/Install.ps1
+++ b/src/Microsoft.Xaml.Behaviors/Install.ps1
@@ -1,0 +1,5 @@
+param($installPath, $toolsPath, $package, $project)
+
+# Remove the reference to the .Design.dll, which is incorrectly referenced during
+# the NuGet package installation in .NET Framework applications (not .NET Core).
+$project.Object.References | Where-Object { $_.Name -eq 'Microsoft.Xaml.Behaviors.Design' } | ForEach-Object { $_.Remove() }

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -96,13 +96,18 @@
                             Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
         <TargetPath>Design</TargetPath>
       </BuildOutputInPackage>
+      <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.Design.dll"
+                            Condition="'$(TargetFramework)' == 'net45'">
+        <TargetPath>Design</TargetPath>
+      </BuildOutputInPackage>
     </ItemGroup>
   </Target>
 
   <Target Name="TimestampNugetPackage">
     <PropertyGroup>
       <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd-HHmm))</CurrentDate>
-      <PackageVersion Condition="'$(TimestampPackage)' == 'true'">$(PackageVersion)-CI-$(CurrentDate)</PackageVersion>
+      <!-- Condition="'$(TimestampPackage)' == 'true'"-->
+      <PackageVersion >$(PackageVersion)-CI-$(CurrentDate)</PackageVersion>
       <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
     </PropertyGroup>
   </Target>

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -90,6 +90,16 @@
     </FilesToSign>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Install.ps1 is for .NET Framework projects (not .NET Core).
+    The script removes the reference to the .Design.dll in the referencing project.
+    It is placed in the root of the project so that it is correctly picked up
+    and placed in the tools/ directory of the NuGet package. -->
+    <Content Include="Install.ps1">
+      <PackagePath>tools\</PackagePath>
+    </Content>
+  </ItemGroup>
+
   <Target Name="IncludeProjectToProjectAssets">
     <ItemGroup>
       <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.DesignTools.dll"
@@ -97,7 +107,7 @@
         <TargetPath>Design</TargetPath>
       </BuildOutputInPackage>
       <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.Design.dll"
-                            Condition="'$(TargetFramework)' == 'net45'">
+                              Condition="'$(TargetFramework)' == 'net45'">
         <TargetPath>Design</TargetPath>
       </BuildOutputInPackage>
     </ItemGroup>

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -116,8 +116,7 @@
   <Target Name="TimestampNugetPackage">
     <PropertyGroup>
       <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd-HHmm))</CurrentDate>
-      <!-- Condition="'$(TimestampPackage)' == 'true'"-->
-      <PackageVersion >$(PackageVersion)-CI-$(CurrentDate)</PackageVersion>
+      <PackageVersion Condition="'$(TimestampPackage)' == 'true'">$(PackageVersion)-CI-$(CurrentDate)</PackageVersion>
       <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
### Description of Change ###

Includes a new Design project for .NET Framework applications, which targets the Designer Isolation architecture.
NuGet package includes an Install.ps1 powershell script that removes the reference to the .Design.dll when adding package to .NET Framework projects. 

### API Changes ###

No public API changes.

### Behavioral Changes ###

Value editors now appear in the property grid when editing behavior properties, such as the SourceObject of the EventTrigger.
