### PR TITLE
Fix issue with build failing in pipeline

### DIFF
--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Debug\net45\Design\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;DesignerIsolation</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Release\net45\Design\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;DesignerIsolation</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -69,7 +69,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);DesignerIsolation</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Xaml.Behaviors.Design</RootNamespace>
     <AssemblyName>Microsoft.Xaml.Behaviors.Design</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Xaml.Behaviors.Design</RootNamespace>
     <AssemblyName>Microsoft.Xaml.Behaviors.Design</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Xaml.Behaviors.Design</RootNamespace>
     <AssemblyName>Microsoft.Xaml.Behaviors.Design</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -35,8 +35,12 @@
     <DefineConstants>$(DefineConstants);DesignerIsolation</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Windows.Design.Extensibility, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
-    <Reference Include="Microsoft.Windows.Design.Interaction, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
+    <Reference Include="Microsoft.Windows.Design.Extensibility, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.Windows.Design.Interaction, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Xaml.Behaviors.Design</RootNamespace>
     <AssemblyName>Microsoft.Xaml.Behaviors.Design</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Debug\net45\Design\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;DesignerIsolation</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,9 +27,12 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Release\net45\Design\</OutputPath>
-    <DefineConstants>TRACE;DesignerIsolation</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);DesignerIsolation</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Windows.Design.Extensibility, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />

--- a/src/Microsoft.Xaml.Behaviors.DesignTools/MetadataTableProvider.cs
+++ b/src/Microsoft.Xaml.Behaviors.DesignTools/MetadataTableProvider.cs
@@ -3,14 +3,14 @@
 
 using System.ComponentModel;
 
-#if DesignerIsolation
-using Microsoft.Windows.Design.Metadata;
-using Microsoft.Windows.Design.PropertyEditing;
-using Editors = Microsoft.Windows.Design.PropertyEditing.Editors;
-#else
+#if SurfaceIsolation
 using Microsoft.VisualStudio.DesignTools.Extensibility.Metadata;
 using Microsoft.VisualStudio.DesignTools.Extensibility.PropertyEditing;
 using Editors = Microsoft.VisualStudio.DesignTools.Extensibility.PropertyEditing.Editors;
+#else
+using Microsoft.Windows.Design.Metadata;
+using Microsoft.Windows.Design.PropertyEditing;
+using Editors = Microsoft.Windows.Design.PropertyEditing.Editors;
 #endif
 
 [assembly: ProvideMetadata(typeof(Microsoft.Xaml.Behaviors.DesignTools.MetadataTableProvider))]

--- a/src/Microsoft.Xaml.Behaviors.DesignTools/Microsoft.Xaml.Behaviors.DesignTools.csproj
+++ b/src/Microsoft.Xaml.Behaviors.DesignTools/Microsoft.Xaml.Behaviors.DesignTools.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Xaml.Behaviors.DesignTools</RootNamespace>
     <AssemblyName>Microsoft.Xaml.Behaviors.DesignTools</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/src/Microsoft.Xaml.Behaviors.DesignTools/Microsoft.Xaml.Behaviors.DesignTools.csproj
+++ b/src/Microsoft.Xaml.Behaviors.DesignTools/Microsoft.Xaml.Behaviors.DesignTools.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Xaml.Behaviors.DesignTools</RootNamespace>
     <AssemblyName>Microsoft.Xaml.Behaviors.DesignTools</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/src/Microsoft.Xaml.Behaviors.DesignTools/Microsoft.Xaml.Behaviors.DesignTools.csproj
+++ b/src/Microsoft.Xaml.Behaviors.DesignTools/Microsoft.Xaml.Behaviors.DesignTools.csproj
@@ -33,6 +33,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);SurfaceIsolation</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.DesignTools.Extensibility, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
     <Reference Include="Microsoft.VisualStudio.DesignTools.Interaction, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />


### PR DESCRIPTION
### Description of Change ###

Changing framework target version of design-time projects to v4.5. There is currently an issue with the pipeline build, which was fixed by targetting v4.7.2. However the projects must target v4.5.
