### PR TITLE
DataTrigger: Evaluate initial value on element load

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/Core/DataTrigger.cs
+++ b/src/Microsoft.Xaml.Behaviors/Core/DataTrigger.cs
@@ -40,6 +40,27 @@ namespace Microsoft.Xaml.Behaviors.Core
         {
         }
 
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            //fixes issue #11. We want to evaluate the binding's initial value when the element is first loaded
+            if (AssociatedObject is FrameworkElement element)
+            {
+                element.Loaded += OnElementLoaded;
+            }
+        }
+
+        private void OnElementLoaded(object sender, RoutedEventArgs e)
+        {
+            EvaluateBindingChange(e);
+
+            if (AssociatedObject is FrameworkElement element)
+            {
+                element.Loaded -= OnElementLoaded;
+            }
+        }
+
         /// <summary>
         /// Called when the binding property has changed. 
         /// UA_REVIEW:chabiss

--- a/src/Microsoft.Xaml.Behaviors/Core/DataTrigger.cs
+++ b/src/Microsoft.Xaml.Behaviors/Core/DataTrigger.cs
@@ -47,17 +47,19 @@ namespace Microsoft.Xaml.Behaviors.Core
             //fixes issue #11. We want to evaluate the binding's initial value when the element is first loaded
             if (AssociatedObject is FrameworkElement element)
             {
+                void OnElementLoaded(object sender, RoutedEventArgs e)
+                {
+                    try
+                    {
+                        this.EvaluateBindingChange(e);
+                    }
+                    finally
+                    {
+                        element.Loaded -= OnElementLoaded;
+                    }                    
+                }
+
                 element.Loaded += OnElementLoaded;
-            }
-        }
-
-        private void OnElementLoaded(object sender, RoutedEventArgs e)
-        {
-            EvaluateBindingChange(e);
-
-            if (AssociatedObject is FrameworkElement element)
-            {
-                element.Loaded -= OnElementLoaded;
             }
         }
 

--- a/src/Microsoft.Xaml.Behaviors/Core/DataTrigger.cs
+++ b/src/Microsoft.Xaml.Behaviors/Core/DataTrigger.cs
@@ -47,19 +47,32 @@ namespace Microsoft.Xaml.Behaviors.Core
             //fixes issue #11. We want to evaluate the binding's initial value when the element is first loaded
             if (AssociatedObject is FrameworkElement element)
             {
-                void OnElementLoaded(object sender, RoutedEventArgs e)
-                {
-                    try
-                    {
-                        this.EvaluateBindingChange(e);
-                    }
-                    finally
-                    {
-                        element.Loaded -= OnElementLoaded;
-                    }                    
-                }
-
                 element.Loaded += OnElementLoaded;
+            }
+        }
+
+        protected override void OnDetaching()
+        {
+            base.OnDetaching();
+            UnsubscribeElementLoadedEvent();
+        }
+
+        private void OnElementLoaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                EvaluateBindingChange(e);
+            } finally
+            {
+                UnsubscribeElementLoadedEvent();
+            }
+        }
+
+        private void UnsubscribeElementLoadedEvent()
+        {
+            if (AssociatedObject is FrameworkElement element)
+            {
+                element.Loaded -= OnElementLoaded;
             }
         }
 


### PR DESCRIPTION
### Description of Change ###

Online 43 of the `DataTrigger.cs` file, added an event handler for the `Loaded` event of the AssociatedObject. Within this handler, we call `EvaluateBindingChange` to force the evaluation of the binding value when the element first loads.  After the element is loaded and the bindings have been evaluated, we immediately unhook the `Loaded` event handler.

Note: tests were not added because I was unable to simulate a loaded event on a UI component. This was tested with a running sample.

### Bugs Fixed ###

- #11

### API Changes ###

None

### Behavioral Changes ###

When an element first loads, the binding value is now evaluated by the DataTrigger.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
