### PR TITLE
Add target framework for .Net Core 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ To use behaviors in your project, add the [Microsoft.Xaml.Behaviors.Wpf](https:/
 Buiding Behaviors from Source
 ------------------------------
 **What You Need**
-
  - [Visual Studio 2017](https://www.visualstudio.com/features/windows-apps-games-vs)
 
 **Clone the Repository**
-
  - Go to 'View' -> 'Team Explorer' -> 'Local Git Repositories' -> 'Clone'
  - Add the XAML Behaviors for WPF repository URL (https://github.com/Microsoft/XamlBehaviorsWpf) and hit 'Clone'
 

--- a/Test/UnitTests/BehaviorUtilities.cs
+++ b/Test/UnitTests/BehaviorUtilities.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
 
         private DebugOutputListener()
         {
-#if !NETCOREAPP3_0
+#if !NETCOREAPP
             this.storedListeners = new TraceListener[Debug.Listeners.Count];
             Debug.Listeners.CopyTo(this.storedListeners, 0);
             Debug.Listeners.Clear();
@@ -197,7 +197,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
 
         public void Dispose()
         {
-#if !NETCOREAPP3_0
+#if !NETCOREAPP
             Debug.Listeners.Clear();
             Debug.Listeners.AddRange(this.storedListeners);
 #endif

--- a/Test/UnitTests/ChangePropertyActionTests.cs
+++ b/Test/UnitTests/ChangePropertyActionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved. 
+﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 namespace Microsoft.Xaml.Interactions.UnitTests
 {
@@ -228,7 +228,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
         }
 
         [TestMethod]
-#if NETCOREAPP3_0
+#if NETCOREAPP
         [ExpectedException(typeof(ArgumentException))]
 #else
         [ExpectedException(typeof(Exception))]

--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.43">
+<Project Sdk="MSBuild.Sdk.Extras/2.0.43">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <UseWPF>true</UseWPF>
     <OutputType>Library</OutputType>

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -103,7 +103,7 @@
   <Target Name="IncludeProjectToProjectAssets">
     <ItemGroup>
       <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.DesignTools.dll"
-                            Condition="'$(TargetFramework.StartsWith('netcoreapp'))">
+                            Condition="'$(TargetFramework.StartsWith('netcoreapp3.'))">
         <TargetPath>Design</TargetPath>
       </BuildOutputInPackage>
       <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.Design.dll"

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.43">
+<Project Sdk="MSBuild.Sdk.Extras/2.0.43">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectToProjectAssets</TargetsForTfmSpecificBuildOutput>
     <OutputType>Library</OutputType>
     <PackageId>Microsoft.Xaml.Behaviors.Wpf</PackageId>
@@ -103,7 +103,7 @@
   <Target Name="IncludeProjectToProjectAssets">
     <ItemGroup>
       <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.DesignTools.dll"
-                            Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+                            Condition="'$(TargetFramework.StartsWith('netcoreapp'))">
         <TargetPath>Design</TargetPath>
       </BuildOutputInPackage>
       <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.Design.dll"


### PR DESCRIPTION
### Description of Change ###

This PR adds the target framework for .Net Core 3.1.

### Bugs Fixed ###

Closes #78 

### API Changes ###

Added:
 - netcoreapp3.1 target framework

### Behavioral Changes ###

-/-

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
