### PR TITLE
Add .Net 5.0 target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,20 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-    - uses: nuget/setup-nuget@v1.0.2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.100
+    - uses: nuget/setup-nuget@v1.0.5
     - name: Restore
       run: nuget restore src/BehaviorsSdk.sln
-    - uses: microsoft/setup-msbuild@v1.0.1
+    - uses: microsoft/setup-msbuild@v1.0.2
     - name: Build
       run: msbuild src/BehaviorsSdk.sln /p:Configuration=Release
+    - name: Pack Behaviors
+      if: success()
+      run: msbuild src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj /p:Configuration=Release -t:pack
+    - name: Upload NuGet Artifacts
+      if: success()
+      uses: actions/upload-artifact@v2
+      with:
+        path: src/Microsoft.Xaml.Behaviors/bin/Release/*.nupkg

--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras/2.0.43">
+<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
   <PropertyGroup>
     <TargetFrameworks>net45;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>

--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
+﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.0;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <UseWPF>true</UseWPF>
     <OutputType>Library</OutputType>
@@ -20,5 +20,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Xaml.Behaviors\Microsoft.Xaml.Behaviors.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.0;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <UseWPF>true</UseWPF>
     <OutputType>Library</OutputType>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pr:
 - rel/*
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-latest
 
 variables:
   buildConfiguration: Release
@@ -19,25 +19,29 @@ steps:
     custom: tool
     arguments: install --tool-path . nbgv
   displayName: Install NBGV tool
-    
+
 - script: nbgv cloud
   displayName: Set Version
 
-- task: MSBuild@1
+- task: UseDotNet@2
+    displayName: 'Use .NET Core sdk 5.0'
+    inputs:
+      packageType: sdk
+      version: 5.0.100
+
+- task: DotNetCoreCLI@2
   displayName: Build Solution
   inputs:
-    solution: src/*.sln
-    msbuildArguments: /restore
-    configuration: $(buildConfiguration)
-    maximumCpuCount: false
+    command: build
+    projects: src/*.sln
+    arguments: '--configuration $(buildConfiguration)'
 
-- task: MSBuild@1
+- task: DotNetCoreCLI@2
   displayName: Pack Behaviors
   inputs:
-    solution: src/**/Microsoft.Xaml.Behaviors.csproj
-    msbuildArguments: /t:Pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)
-    configuration: $(buildConfiguration)
-    maximumCpuCount: false
+    command: pack
+    packagesToPack: src/**/Microsoft.Xaml.Behaviors.csproj
+    arguments: '--configuration $(buildConfiguration)'
 
 - task: VSTest@2
   displayName: Run Tests

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras/2.0.43">
+<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
   <PropertyGroup>
     <TargetFrameworks>net45;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectToProjectAssets</TargetsForTfmSpecificBuildOutput>

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="MSBuild.Sdk.Extras/2.1.2">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.0;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectToProjectAssets</TargetsForTfmSpecificBuildOutput>
     <OutputType>Library</OutputType>
     <PackageId>Microsoft.Xaml.Behaviors.Wpf</PackageId>
@@ -35,7 +35,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)'=='net45'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -76,7 +76,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.38" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -103,7 +103,7 @@
   <Target Name="IncludeProjectToProjectAssets">
     <ItemGroup>
       <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.DesignTools.dll"
-                            Condition="'$(TargetFramework.StartsWith('netcoreapp3.'))">
+                            Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))">
         <TargetPath>Design</TargetPath>
       </BuildOutputInPackage>
       <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.Design.dll"

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="MSBuild.Sdk.Extras/2.1.2">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.0;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectToProjectAssets</TargetsForTfmSpecificBuildOutput>
     <OutputType>Library</OutputType>
     <PackageId>Microsoft.Xaml.Behaviors.Wpf</PackageId>


### PR DESCRIPTION
### Description of Change ###

This PR adds the target framework for .Net 5.0.

### Bugs Fixed ###

Closes #80 

### API Changes ###

Added:
 - net5.0-windows target framework

### Behavioral Changes ###

-/-

![image](https://user-images.githubusercontent.com/658431/99779595-9213a280-2b15-11eb-90e6-38cd11e4941e.png)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard

### Note ###

Should we drop the netcoreapp3.0 target?