### PR TITLE
Gets the parent and templated parent element of the associated object.

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/Layout/MouseDragElementBehavior.cs
+++ b/src/Microsoft.Xaml.Behaviors/Layout/MouseDragElementBehavior.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
         {
             get
             {
-                return this.AssociatedObject.Parent as FrameworkElement;
+                return (base.AssociatedObject.Parent ?? base.AssociatedObject.TemplatedParent) as FrameworkElement;
             }
         }
 


### PR DESCRIPTION
### Description of Change ###

Parent is null in DataTemplate.

