### PR TITLE
Fix for #93

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/Input/KeyTrigger.cs
+++ b/src/Microsoft.Xaml.Behaviors/Input/KeyTrigger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved. 
+﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 namespace Microsoft.Xaml.Behaviors.Input
 {
@@ -111,10 +111,14 @@ namespace Microsoft.Xaml.Behaviors.Input
 
             if (this.FiredOn == KeyTriggerFiredOn.KeyDown)
             {
+                //remove KeyDown event to avoid duplicate events
+                this.targetElement.KeyDown -= this.OnKeyPress;
                 this.targetElement.KeyDown += this.OnKeyPress;
             }
             else
             {
+                //remove KeyUp event to avoid duplicate events
+                this.targetElement.KeyUp -= this.OnKeyPress;
                 this.targetElement.KeyUp += this.OnKeyPress;
             }
         }


### PR DESCRIPTION
### Description of Change ###

A fix for a situation in which KeyTriggrs are executed twice, after unloading and reloading a component. There is no Unloaded handling on the associated element in the EventTriggerBase. Implementing this might be a better solution, but this may cause side effects in other implementations

### Bugs Fixed ###

- #93 

### API Changes ###

- [ ] Has tests, unloading, loading visuals in Unit test not possible
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
