### PR TITLE
Remove unnessary return statement to trigger new build version

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/VisualStateUtilities.cs
+++ b/src/Microsoft.Xaml.Behaviors/VisualStateUtilities.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Xaml.Behaviors
         /// Gets the value of the VisualStateManager.VisualStateGroups attached property.
         /// </summary>
         /// <param name="targetObject">The element from which to get the VisualStateManager.VisualStateGroups.</param>
-        /// <returns></returns>
         public static IList GetVisualStateGroups(FrameworkElement targetObject)
         {
             IList visualStateGroups = new List<VisualStateGroup>();


### PR DESCRIPTION
### Description of Change ###
Remove unnecessary comment to trigger new build version.

### Why ###
We are trying to update the symbols in the nuget packages to be non-portable .pdbs so that they resolve with symchk. We've changed the msbuild arguments in the release pipeline to achieve this. Since there is no code change, we are unable to generate a newer nuget package version. Hence this PR. Since the build versions and subsequently, the nugetpackage versions are controlled by Nerdbank.GitVersioning, this is the only way to trigger a newer build version. 
