### PR TITLE
Fixed #107

### DIFF
--- a/Test/UnitTests/EventTriggerTests.cs
+++ b/Test/UnitTests/EventTriggerTests.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Xaml.Interactions.UnitTests
 
         [TestInitialize]
         public void Setup()
-            {
-                Interaction.ShouldRunInDesignMode = true;
-            }
+        {
+            Interaction.ShouldRunInDesignMode = true;
+        }
 
         [TestCleanup]
         public void Teardown()

--- a/Test/UnitTests/KeyTriggerTest.cs
+++ b/Test/UnitTests/KeyTriggerTest.cs
@@ -1,0 +1,181 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xaml.Behaviors;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows;
+using Microsoft.Xaml.Behaviors.Input;
+using System.Windows.Interop;
+using System;
+
+namespace Microsoft.Xaml.Interactions.UnitTests
+{
+    [TestClass]
+    public class KeyTriggerTest
+    {
+        #region Setup/teardown
+
+        [TestInitialize]
+        public void Setup()
+        {
+            Interaction.ShouldRunInDesignMode = true;
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            Interaction.ShouldRunInDesignMode = false;
+        }
+
+        #endregion
+
+        #region Test methods
+
+        [TestMethod]
+        [DataRow(Key.A)]
+        [DataRow(Key.B)]
+        [DataRow(Key.C)]
+        [DataRow(Key.D)]
+        [DataRow(Key.E)]
+        [DataRow(Key.F)]
+        [DataRow(Key.G)]
+        [DataRow(Key.H)]
+        [DataRow(Key.I)]
+        [DataRow(Key.J)]
+        [DataRow(Key.K)]
+        [DataRow(Key.L)]
+        [DataRow(Key.M)]
+        [DataRow(Key.N)]
+        [DataRow(Key.O)]
+        [DataRow(Key.P)]
+        [DataRow(Key.Q)]
+        [DataRow(Key.R)]
+        [DataRow(Key.S)]
+        [DataRow(Key.T)]
+        [DataRow(Key.U)]
+        [DataRow(Key.V)]
+        [DataRow(Key.W)]
+        [DataRow(Key.X)]
+        [DataRow(Key.Y)]
+        [DataRow(Key.Z)]
+        [DataRow(Key.NumPad1)]
+        [DataRow(Key.NumPad2)]
+        [DataRow(Key.NumPad3)]
+        [DataRow(Key.NumPad4)]
+        [DataRow(Key.NumPad5)]
+        [DataRow(Key.NumPad6)]
+        [DataRow(Key.NumPad7)]
+        [DataRow(Key.NumPad8)]
+        [DataRow(Key.NumPad9)]
+        [DataRow(Key.Enter)]
+        [DataRow(Key.Tab)]
+        public void KeyTrigger_InvokesActions_WhenKeyIsPressed(Key key)
+        {
+            var textBox = new TextBox();
+            var keyTrigger = new KeyTrigger { Key = key };
+            var action = new StubAction();
+            keyTrigger.Actions.Add(action);
+            keyTrigger.Attach(textBox);
+
+            Grid grid = new Grid();
+            grid.Children.Add(textBox);
+            using (StubWindow window = new StubWindow(grid))
+            {
+                var inputSource = PresentationSource.FromVisual(textBox) ?? new HwndSource(0, 0, 0, 0, 0, "", IntPtr.Zero);
+                var keyEventArgs = new KeyEventArgs(Keyboard.PrimaryDevice, inputSource, 0, key);
+                keyEventArgs.RoutedEvent = Keyboard.KeyDownEvent;
+                textBox.RaiseEvent(keyEventArgs);
+
+                Assert.AreEqual(1, action.InvokeCount);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(Key.A)]
+        [DataRow(Key.B)]
+        [DataRow(Key.C)]
+        [DataRow(Key.D)]
+        [DataRow(Key.E)]
+        [DataRow(Key.F)]
+        [DataRow(Key.G)]
+        [DataRow(Key.H)]
+        [DataRow(Key.I)]
+        [DataRow(Key.J)]
+        [DataRow(Key.K)]
+        [DataRow(Key.L)]
+        [DataRow(Key.M)]
+        [DataRow(Key.N)]
+        [DataRow(Key.O)]
+        [DataRow(Key.P)]
+        [DataRow(Key.Q)]
+        [DataRow(Key.R)]
+        [DataRow(Key.S)]
+        [DataRow(Key.T)]
+        [DataRow(Key.U)]
+        [DataRow(Key.V)]
+        [DataRow(Key.W)]
+        [DataRow(Key.X)]
+        [DataRow(Key.Y)]
+        [DataRow(Key.Z)]
+        [DataRow(Key.NumPad1)]
+        [DataRow(Key.NumPad2)]
+        [DataRow(Key.NumPad3)]
+        [DataRow(Key.NumPad4)]
+        [DataRow(Key.NumPad5)]
+        [DataRow(Key.NumPad6)]
+        [DataRow(Key.NumPad7)]
+        [DataRow(Key.NumPad8)]
+        [DataRow(Key.NumPad9)]
+        [DataRow(Key.Enter)]
+        [DataRow(Key.Tab)]
+        public void KeyTrigger_InvokesActions_WhenKeyIsReleased(Key key)
+        {
+            var textBox = new TextBox();
+            var keyTrigger = new KeyTrigger { Key = key, FiredOn = KeyTriggerFiredOn.KeyUp };
+            var action = new StubAction();
+            keyTrigger.Actions.Add(action);
+            keyTrigger.Attach(textBox);
+
+            Grid grid = new Grid();
+            grid.Children.Add(textBox);
+            using (StubWindow window = new StubWindow(grid))
+            {
+                var inputSource = PresentationSource.FromVisual(textBox) ?? new HwndSource(0, 0, 0, 0, 0, "", IntPtr.Zero);
+                var keyEventArgs = new KeyEventArgs(Keyboard.PrimaryDevice, inputSource, 0, key);
+                keyEventArgs.RoutedEvent = Keyboard.KeyUpEvent;
+                textBox.RaiseEvent(keyEventArgs);
+
+                Assert.AreEqual(1, action.InvokeCount);
+            }
+        }
+
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void KeyTrigger_InvokesActionsOnce_WhenLoadedEventFiredMultipleTimes(bool activeOnFocus)
+        {
+            var textBox = new TextBox();
+            var keyTrigger = new KeyTrigger { ActiveOnFocus = activeOnFocus, Key = Key.Enter };
+            var action = new StubAction();
+            keyTrigger.Actions.Add(action);
+            keyTrigger.Attach(textBox);
+
+            Grid grid = new Grid();
+            grid.Children.Add(textBox);
+            using (StubWindow window = new StubWindow(grid))
+            {
+                //simulate the loaded event being invoked multiple times; for example, when using an element in a tab control
+                textBox.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+                var inputSource = PresentationSource.FromVisual(textBox) ?? new HwndSource(0, 0, 0, 0, 0, "", IntPtr.Zero);
+                var keyEventArgs = new KeyEventArgs(Keyboard.PrimaryDevice, inputSource, 0, Key.Enter);
+                keyEventArgs.RoutedEvent = Keyboard.KeyDownEvent;
+                textBox.RaiseEvent(keyEventArgs);
+
+                Assert.AreEqual(1, action.InvokeCount);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-     <PackageReference Include="Moq" Version="4.18.4" />
      <PackageReference Include="MSTest.TestAdapter">
       <Version>3.0.2</Version>
     </PackageReference>

--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+     <PackageReference Include="Moq" Version="4.18.4" />
      <PackageReference Include="MSTest.TestAdapter">
       <Version>3.0.2</Version>
     </PackageReference>

--- a/src/Microsoft.Xaml.Behaviors/EventTriggerBase.cs
+++ b/src/Microsoft.Xaml.Behaviors/EventTriggerBase.cs
@@ -408,7 +408,11 @@ namespace Microsoft.Xaml.Behaviors
             }
         }
 
-        private void UnregisterLoaded(FrameworkElement associatedElement)
+        /// <summary>
+        /// Removes the event handler from the Loaded event of the associated object.
+        /// </summary>
+        /// <param name="associatedElement">The associated object</param>
+        protected void UnregisterLoaded(FrameworkElement associatedElement)
         {
             Debug.Assert(this.eventHandlerMethodInfo == null);
             if (this.IsLoadedRegistered && associatedElement != null)

--- a/src/Microsoft.Xaml.Behaviors/Input/KeyTrigger.cs
+++ b/src/Microsoft.Xaml.Behaviors/Input/KeyTrigger.cs
@@ -117,6 +117,10 @@ namespace Microsoft.Xaml.Behaviors.Input
             {
                 this.targetElement.KeyUp += this.OnKeyPress;
             }
+
+            // Unregister the Loaded event of the Source object to prevent the KeyUp or KeyDown events from being registered multiple times.
+            // this is especially important when the KeyTrigger is used in a TabControl/TabItem.
+            UnregisterLoaded(Source as FrameworkElement);
         }
 
         protected override void OnDetaching()


### PR DESCRIPTION
### Description of Change ###

Fixed #107.

KeyTrigger would fire multiple times due to the Loaded event being invoked multiple times. This would cause the KeyUp/KeyDown events to be registered multiple times and therefore invoke the trigger multiple times.

Added code to remove the `Loaded` event handler from the source object to prevent the Loaded event from firing multiple times.

### Bugs Fixed ###

- #107

### API Changes ###

List all API changes here (or just put None), example:

Changed:
 - private void UnregisterLoaded() => protected void UnregisterLoaded()

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
