### PR TITLE
Removed use of MSBuild.Sdk.Extras

### DIFF
--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
     <IsPackable>false</IsPackable>

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectToProjectAssets</TargetsForTfmSpecificBuildOutput>


### PR DESCRIPTION
### Description of Change ###

Since we no longer support .NET Core 3.1 or .NET 5, the need for the MSBuild.Sdk.Extras is no longer required.

Changed the Behaviors and UnitTests project to use the official Microsoft.NET.Sdk

### Bugs Fixed ###

- #126
