### PR TITLE
Make TriggerCollection constructor public

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/TriggerCollection.cs
+++ b/src/Microsoft.Xaml.Behaviors/TriggerCollection.cs
@@ -3,18 +3,17 @@
 namespace Microsoft.Xaml.Behaviors
 {
     using System.Windows;
-    using System.ComponentModel;
 
     ///<summary>
     /// Represents a collection of triggers with a shared AssociatedObject and provides change notifications to its contents when that AssociatedObject changes.
     /// </summary>
+    /// <remarks>Sealed, because this should not be inherited outside this assembly.</remarks>
     public sealed class TriggerCollection : AttachableCollection<TriggerBase>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriggerCollection"/> class.
         /// </summary>
-        /// <remarks>Internal, because this should not be inherited outside this assembly.</remarks>
-        internal TriggerCollection()
+        public TriggerCollection()
         {
         }
 


### PR DESCRIPTION
### Description of Change ###

Make TriggerCollection constructor public.

### Bugs Fixed ###

Fixes #103 

### API Changes ###

Changed:
 - internal TriggerCollection() => public TriggerCollection()


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
