### PR TITLE
Updated DesignTools project's output path

### DIFF
--- a/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
+++ b/src/Microsoft.Xaml.Behaviors.Design/Microsoft.Xaml.Behaviors.Design.csproj
@@ -22,7 +22,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Debug\net45\Design\</OutputPath>
+    <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Debug\net462\Design\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -30,7 +30,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Release\net45\Design\</OutputPath>
+    <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Release\net462\Design\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/Microsoft.Xaml.Behaviors.DesignTools/Microsoft.Xaml.Behaviors.DesignTools.csproj
+++ b/src/Microsoft.Xaml.Behaviors.DesignTools/Microsoft.Xaml.Behaviors.DesignTools.csproj
@@ -24,7 +24,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Debug\net45\Design\</OutputPath>
+    <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Debug\net462\Design\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -32,7 +32,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Release\net45\Design\</OutputPath>
+    <OutputPath>..\Microsoft.Xaml.Behaviors\bin\Release\net462\Design\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -89,10 +89,10 @@
   
   <Target Name="IncludeProjectToProjectAssets">
     <ItemGroup>
-      <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.DesignTools.dll" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))">
+      <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net462\Design\Microsoft.Xaml.Behaviors.DesignTools.dll" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))">
         <TargetPath>Design</TargetPath>
       </BuildOutputInPackage>
-      <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net45\Design\Microsoft.Xaml.Behaviors.Design.dll" Condition="'$(TargetFramework)' == 'net45'">
+      <BuildOutputInPackage Include="$(ProjectDir)bin\$(Configuration)\net462\Design\Microsoft.Xaml.Behaviors.Design.dll" Condition="'$(TargetFramework)' == 'net462'">
         <TargetPath>Design</TargetPath>
       </BuildOutputInPackage>
     </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Modified the build output path of the DesignTools projects from the old `net45` to `net462` due to the recent framework upgrades.

### Bugs Fixed ###

- Related to work done for #102

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
