### PR TITLE
House Keeping

### DIFF
--- a/Test/UnitTests/BehaviorUtilities.cs
+++ b/Test/UnitTests/BehaviorUtilities.cs
@@ -168,8 +168,10 @@ namespace Microsoft.Xaml.Interactions.UnitTests
         }
         #endregion
 
+#if !NETCOREAPP
         private TraceListener[] storedListeners;
-        private DebugTraceListener debugTraceListener;
+#endif
+        private DebugTraceListener debugTraceListener = new DebugTraceListener();
 
         public List<string> Messages
         {

--- a/src/Microsoft.Xaml.Behaviors/Core/ExtendedVisualStateManager.cs
+++ b/src/Microsoft.Xaml.Behaviors/Core/ExtendedVisualStateManager.cs
@@ -779,6 +779,7 @@ namespace Microsoft.Xaml.Behaviors.Core
         /// Subsequent code will check these rectangles both before and after the layout change.
         /// </summary>
         /// <param name="control">The control whose layout is changing state.</param>
+        /// <param name="templateRoot">The template root.</param>
         /// <param name="layoutStoryboard">The storyboard containing the layout changes.</param>
         /// <param name="originalValueRecords">Any previous values from previous state navigations that might be reverted.</param>
         /// <param name="movingElements">The set of elements currently in motion, if there is a state change transition ongoing.</param>
@@ -1014,8 +1015,10 @@ namespace Microsoft.Xaml.Behaviors.Core
         /// Get the opacities of elements at the time of the state change, instead of visibilities, because the state change may be in process and the current value is the most important.
         /// </summary>
         /// <param name="control">The control whose state is changing.</param>
+        /// <param name="templateRoot">The template root.</param>
         /// <param name="layoutStoryboard">The storyboard with the layout properties.</param>
         /// <param name="originalValueRecords">The set of original values.</param>
+        /// <param name="movingElements">The elements currently in motion</param>
         /// <returns></returns>
         private static Dictionary<FrameworkElement, double> GetOldOpacities(FrameworkElement control, FrameworkElement templateRoot, Storyboard layoutStoryboard, List<OriginalLayoutValueRecord> originalValueRecords, List<FrameworkElement> movingElements)
         {
@@ -1078,6 +1081,7 @@ namespace Microsoft.Xaml.Behaviors.Core
         /// All values that are overwritten will be stored in the collection of OriginalValueRecords so that they can be replaced later.
         /// </summary>
         /// <param name="control">The control whose state is changing.</param>
+        /// <param name="templateRoot">The template root.</param>
         /// <param name="layoutStoryboard">The Storyboard holding the layout properties.</param>
         /// <param name="originalValueRecords">The store of original values.</param>
         [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "This is done in a single pass for performance reasons.")]
@@ -1186,6 +1190,8 @@ namespace Microsoft.Xaml.Behaviors.Core
         /// they do not affect their sibling elements.
         /// </summary>
         /// <param name="movingElements">The set of elements that will be moving.</param>
+        /// <param name="oldRects">The old Rect.</param>
+        /// <param name="newRects">The new Rect.</param>
         private static void WrapMovingElementsInCanvases(List<FrameworkElement> movingElements, Dictionary<FrameworkElement, Rect> oldRects, Dictionary<FrameworkElement, Rect> newRects)
         {
             foreach (FrameworkElement movedElement in movingElements)
@@ -1286,6 +1292,7 @@ namespace Microsoft.Xaml.Behaviors.Core
         /// </summary>
         /// <param name="source">The source of the layout properties.</param>
         /// <param name="target">The destination of the layout properties.</param>
+        /// <param name="restoring">A flag to indicate if a restore is occuring.</param>
         private static void CopyLayoutProperties(FrameworkElement source, FrameworkElement target, bool restoring)
         {
             WrapperCanvas parentCanvas = (restoring ? source : target) as WrapperCanvas;
@@ -1339,8 +1346,7 @@ namespace Microsoft.Xaml.Behaviors.Core
         /// <summary>
         /// Create the actual Storyboard that will be used to animate the transition. Use all previously calculated results.
         /// </summary>
-        /// <param name="duration">The duration of the animation.</param>
-        /// <param name="ease">The easing function to be used in the animation.</param>
+        /// <param name="transition">The transition.</param>
         /// <param name="movingElements">The set of elements that will be moving.</param>
         /// <param name="oldOpacities">The old opacities of the elements whose visibility properties are changing.</param>
         /// <returns>The Storyboard.</returns>

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -30,22 +30,6 @@
   
   <Import Project="..\Microsoft.Xaml.Behaviors.Signing.targets" />
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.XML" />
-    <Reference Include="WindowsBase">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="PresentationCore">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="PresentationFramework">
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-
   <ItemGroup>
     <Compile Update="ExceptionStringTable.Designer.cs">
       <SubType>Code</SubType>
@@ -71,10 +55,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -24,16 +24,7 @@
     <UseWPF>true</UseWPF>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);TimestampNugetPackage</GenerateNuspecDependsOn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net462|AnyCPU'">
-    <NoWarn>1701;1702;1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net462|AnyCPU'">
-    <NoWarn>1701;1702;1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0-windows|AnyCPU'">
-    <NoWarn>1701;1702;1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0-windows|AnyCPU'">
+  <PropertyGroup>
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
   

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -23,8 +23,6 @@
     <DefineConstants>WPF;$(DefineConstants)</DefineConstants>
     <UseWPF>true</UseWPF>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);TimestampNugetPackage</GenerateNuspecDependsOn>
-  </PropertyGroup>
-  <PropertyGroup>
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
   

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -24,8 +24,17 @@
     <UseWPF>true</UseWPF>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);TimestampNugetPackage</GenerateNuspecDependsOn>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net462|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net462|AnyCPU'">
-    <NoWarn>1701;1702;</NoWarn>
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0-windows|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0-windows|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
   
   <Import Project="..\Microsoft.Xaml.Behaviors.Signing.targets" />

--- a/src/Microsoft.Xaml.Behaviors/packages.config
+++ b/src/Microsoft.Xaml.Behaviors/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MicroBuild.Core" version="0.3.0" targetFramework="net40" developmentDependency="true" />
-  <package id="NuGet.Build.Tasks.Pack" version="4.8.0" targetFramework="net40" />
-</packages>


### PR DESCRIPTION
### Description of Change ###

Removed unneeded references in the csproj file. Since we are using SDK style projects, we no longer need to explicitly include the net462 assembly references

Added an additional 1591 as a `NoWarn`. We have a number of public properties an methods with no XML documentation. Until an effort is made to add them, the 1591 warning is pointless.

Removed the no longer needed packages.config file.
