### PR TITLE
Remove Microsoft.Xaml.Behaviors.DesignTools in install.ps1

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/Install.ps1
+++ b/src/Microsoft.Xaml.Behaviors/Install.ps1
@@ -2,4 +2,4 @@ param($installPath, $toolsPath, $package, $project)
 
 # Remove the reference to the .Design.dll, which is incorrectly referenced during
 # the NuGet package installation in .NET Framework applications (not .NET Core).
-$project.Object.References | Where-Object { $_.Name -eq 'Microsoft.Xaml.Behaviors.Design' } | ForEach-Object { $_.Remove() }
+$project.Object.References | Where-Object { $_.Name -eq 'Microsoft.Xaml.Behaviors.Design' -or $_.Name -eq 'Microsoft.Xaml.Behaviors.DesignTools' } | ForEach-Object { $_.Remove() }


### PR DESCRIPTION
### Description of Change ###

Just like `Microsoft.Xaml.Behaviors.Design`, the `Microsoft.Xaml.Behaviors.DesignTools` reference also needs to be removed in install.ps1.

### Bugs Fixed ###

Fixes #142 