### PR TITLE
Updating the command parameter binding for the ColorCommand property so null isn't being passed as the parameter value.

### DIFF
--- a/samples/XAMLBehaviorsSample/XAMLBehaviorsSample/InvokeCommandControl.xaml
+++ b/samples/XAMLBehaviorsSample/XAMLBehaviorsSample/InvokeCommandControl.xaml
@@ -24,7 +24,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            
+
             <Grid Grid.Column="0" Margin="0,0,10,0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="2*"/>
@@ -35,7 +35,7 @@
                 <Button x:Name="button" Content="Click Me" HorizontalAlignment="Stretch" Grid.Row="1" Margin="0,10,0,10">
                     <Behaviors:Interaction.Triggers>
                         <Behaviors:EventTrigger EventName="Click" SourceObject="{Binding ElementName=button}">
-                            <Behaviors:InvokeCommandAction Command="{Binding ColorCommand}" CommandParameter="{Binding Grid.Background}" />
+                            <Behaviors:InvokeCommandAction Command="{Binding ColorCommand}" CommandParameter="{Binding Background, ElementName=Grid}" />
                         </Behaviors:EventTrigger>
                     </Behaviors:Interaction.Triggers>
                 </Button>
@@ -48,7 +48,7 @@
                     </TextBlock>
                     <TextBlock TextWrapping="Wrap" Margin="10,20,0,0" FontSize="15" Foreground="DeepPink" xml:space="preserve">&lt;Behaviors:Interaction.Triggers>
     &lt;Behaviors:EventTrigger EventName="Click" SourceObject="{Binding ElementName=button}">
-        &lt;Behaviors:InvokeCommandAction Command="{Binding ColorCommand}" CommandParameter="{Binding Grid.Background}" />
+        &lt;Behaviors:InvokeCommandAction Command="{Binding ColorCommand}" CommandParameter="{Binding Background, ElementName=Grid}" />
     &lt;/Behaviors:EventTrigger>
 &lt;/Behaviors:Interaction.Triggers>
                     </TextBlock>

--- a/samples/XAMLBehaviorsSample/XAMLBehaviorsSample/InvokeCommandControl.xaml.cs
+++ b/samples/XAMLBehaviorsSample/XAMLBehaviorsSample/InvokeCommandControl.xaml.cs
@@ -40,12 +40,12 @@ namespace XAMLBehaviorsSample
 
         public void Execute(object parameter)
         {
-            Brush currentBackground = this.control.Grid.Background;
+            Brush currentBackground = (Brush)parameter;
+
             if (currentBackground != Brushes.DarkBlue)
             {
                 this.control.Grid.Background = Brushes.DarkBlue;
-            }
-            else
+            } else
             {
                 this.control.Grid.Background = Brushes.DeepPink;
             }


### PR DESCRIPTION
### Description of Change ###

Fixing the broken binding that was always passing `null` into the command.   Explicitly stated the element name and then passed in the 'Background' property.   Cast the parameter in the code behind with the Command

### Bugs Fixed ###

This should fix the issue found in (Issue #144)[https://github.com/microsoft/XamlBehaviorsWpf/issues/144].

Changed:
 - void Execute(object parameter)
 - InvokeCommandControl.xaml

### Behavioral Changes ###

No changes to behavior are expected.

