### PR TITLE
Attempt to fix build signing errors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\src\Behaviors.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -8,8 +8,8 @@ variables:
 - name: Codeql.Enabled
   value: true
 - name: SignType
-  ${{ if ne( variables['Build.Reason'], 'PullRequest' ) }}:
-    value: test
+  ${{ if eq(variables['Build.OfficialRelease'], 'true') }}:
+    value: real
   ${{ else }}:
     value: test
 - name: TeamName
@@ -92,11 +92,11 @@ extends:
         - task: NuGetCommand@2
           displayName: NuGet restore
         - task: VSBuild@1
-          displayName: Build solution src\BehaviorsSDK.sln
+          displayName: Build solution src\BehaviorsSdk.sln
           inputs:
             vsVersion: $(BuildParameters.vsVersion)
             solution: src\BehaviorsSdk.sln
-            msbuildArgs: /p:NoWarn=1591 /p:DebugType=full
+            msbuildArgs: /p:SignType=$(SignType) /p:NoWarn=1591 /p:DebugType=full
             configuration: Release
             maximumCpuCount: true
         - task: VSTest@2

--- a/src/Microsoft.Xaml.Behaviors.Signing.targets
+++ b/src/Microsoft.Xaml.Behaviors.Signing.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
-    <DelaySign>true</DelaySign>
+    <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>..\FinalPublicKey.snk</AssemblyOriginatorKeyFile>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);TimestampNugetPackage</GenerateNuspecDependsOn>
   </PropertyGroup>


### PR DESCRIPTION
- Default DelaySign to false
- Use SignType=real when Build.OfficialRelease=true
- Explicitly pass /p:SignType=$(SignType) in the msbuild command
- Remove <SignAssembly>true</SignAssembly> from Directory.Build.props. This conflicts with the Signing.targets
