### PR TITLE
Re-enable DelaySign

### DIFF
--- a/src/Microsoft.Xaml.Behaviors.Signing.targets
+++ b/src/Microsoft.Xaml.Behaviors.Signing.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
-    <DelaySign>false</DelaySign>
+    <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>..\FinalPublicKey.snk</AssemblyOriginatorKeyFile>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);TimestampNugetPackage</GenerateNuspecDependsOn>
   </PropertyGroup>


### PR DESCRIPTION
Turns out this wasn't the cause of the build signing issues.
