### PR TITLE
Re-add Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\src\Behaviors.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
THese are needed or the UnitTest project fails to build.
