### PR TITLE
Don't pass /p:SignType=$(SignType) explicitly when building Behaviors…

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -96,7 +96,7 @@ extends:
           inputs:
             vsVersion: $(BuildParameters.vsVersion)
             solution: src\BehaviorsSdk.sln
-            msbuildArgs: /p:SignType=$(SignType) /p:NoWarn=1591 /p:DebugType=full /v:diagnostic
+            msbuildArgs: /p:NoWarn=1591 /p:DebugType=full /v:diagnostic
             configuration: Release
             maximumCpuCount: true
         - task: VSTest@2


### PR DESCRIPTION
…Sdk.sln

This is the only meaningful difference I can find between the old classic pipeline and the new pipeline that involves signing.
