### PR TITLE
Explicitly set DelaySign=true for Microsoft.Xaml.Behaviors.dll

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/AssemblyInfo.cs
+++ b/src/Microsoft.Xaml.Behaviors/AssemblyInfo.cs
@@ -40,4 +40,5 @@ using Microsoft.Xaml.Behaviors;
 [assembly: SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Scope = "namespace", Target = "Microsoft.Xaml.Behaviors")]
 
 [assembly: AssemblyKeyFile("..\\Behaviors.snk")]
+[assembly: AssemblyDelaySign(true)]
 [assembly: InternalsVisibleTo("UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100e5435599803109fe684072f487ec0670f2766325a25d47089633ffb5d9a56bf115a705bc0632660aeecfe00248951540865f481613845080859feafc5d9b55750395e7ca4c2124136d17bc9e73f0371d802fc2c9e8308f6f8b0ab3096661d2d1b0cbbbcb6de3fe711ef415f29271088537081b09ad1ee08ce8020b22031cdebd")]

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -24,6 +24,7 @@
     <UseWPF>true</UseWPF>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);TimestampNugetPackage</GenerateNuspecDependsOn>
     <NoWarn>1701;1702;1591</NoWarn>
+    <DelaySign>true</DelaySign>
   </PropertyGroup>
   
   <Import Project="..\Microsoft.Xaml.Behaviors.Signing.targets" />


### PR DESCRIPTION
May fix the signing issue.

Trevor recommended these fixes as a way to solve the build/signing issue. Hopefully this works.