### PR TITLE
Explicitly set Codeql.Language=csharp

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -7,6 +7,8 @@ variables:
   value: false
 - name: Codeql.Enabled
   value: true
+- name: Codeql.Language
+  value: csharp
 - name: SignType
   ${{ if eq(variables['Build.OfficialRelease'], 'true') }}:
     value: real


### PR DESCRIPTION
### Description of Change ###

Explicitly sets the CodeQL language so that failures don't happen for non-C#

### Bugs Fixed ###

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1994378

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
