### PR TITLE
fixing modifiers behavior

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/Input/KeyTrigger.cs
+++ b/src/Microsoft.Xaml.Behaviors/Input/KeyTrigger.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Xaml.Behaviors.Input
 
         public static readonly DependencyProperty FiredOnProperty = DependencyProperty.Register("FiredOn", typeof(KeyTriggerFiredOn), typeof(KeyTrigger));
 
+        public static readonly DependencyProperty UseModifiersAsKeyProperty = DependencyProperty.Register("UseModifiersAsKey", typeof(bool), typeof(KeyTrigger));
+
         private UIElement targetElement;
 
         /// <summary>
@@ -65,6 +67,14 @@ namespace Microsoft.Xaml.Behaviors.Input
             get { return (KeyTriggerFiredOn)this.GetValue(KeyTrigger.FiredOnProperty); }
             set { this.SetValue(KeyTrigger.FiredOnProperty, value); }
         }
+        /// <summary>
+        /// Determines whether to use the Modifiers as a key.
+        /// </summary>
+        public bool UseModifiersAsKey
+        {
+            get { return (bool)this.GetValue(KeyTrigger.UseModifiersAsKeyProperty); }
+            set { this.SetValue(KeyTrigger.UseModifiersAsKeyProperty, value); }
+        }
 
         protected override string GetEventName()
         {
@@ -74,8 +84,10 @@ namespace Microsoft.Xaml.Behaviors.Input
         private void OnKeyPress(object sender, KeyEventArgs e)
         {
             bool isKeyMatch = e.Key == this.Key;
-            bool isModifiersMatch = this.Modifiers == ModifierKeys.None ? true : Keyboard.Modifiers == GetActualModifiers(e.Key, this.Modifiers);
-
+            bool isModifiersMatch = this.UseModifiersAsKey ?
+                this.Modifiers == ModifierKeys.None || Keyboard.Modifiers == GetActualModifiers(e.Key, this.Modifiers) :
+                Keyboard.Modifiers == GetActualModifiers(e.Key, this.Modifiers);
+            
             if (isKeyMatch && isModifiersMatch)
             {
                 this.InvokeActions(e);


### PR DESCRIPTION
### Description of Change ###

We add back the previous behavior described in the issue https://github.com/microsoft/XamlBehaviorsWpf/issues/162 and added backward compatiblity to https://github.com/microsoft/XamlBehaviorsWpf/issues/77

### Bugs Fixed ###

Fixing issue https://github.com/microsoft/XamlBehaviorsWpf/issues/162

### API Changes ###

List all API changes here (or just put None), example:

Added:
- DependencyProperty UseModifiersAsKeyProperty
- Property UseModifiersAsKey

Changed:
 -  OnKeyPress(object sender, KeyEventArgs e)

### Behavioral Changes ###

We added a new dependency property to set if the modifiers have to be considered as normal key button or a real modifier

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
