### PR TITLE
Improved KeyTrigger logic

### DIFF
--- a/Test/UnitTests/KeyTriggerTest.cs
+++ b/Test/UnitTests/KeyTriggerTest.cs
@@ -141,6 +141,72 @@ namespace Microsoft.Xaml.Interactions.UnitTests
         [DataRow(Key.System)]
         [DataRow(Key.LeftShift)]
         [DataRow(Key.RightShift)]
+        public void KeyTrigger_DoesNotInvokeAction_WhenKeyIsPressed(Key key)
+        {
+            var textBox = new TextBox();
+            var keyTrigger = new KeyTrigger { Key = key, Modifiers = ModifierKeys.Control }; //since we have a modifier key, the action should not be invoked
+            var action = new StubAction();
+            keyTrigger.Actions.Add(action);
+            keyTrigger.Attach(textBox);
+
+            Grid grid = new Grid();
+            grid.Children.Add(textBox);
+            using (StubWindow window = new StubWindow(grid))
+            {
+                var inputSource = PresentationSource.FromVisual(textBox) ?? new HwndSource(0, 0, 0, 0, 0, "", IntPtr.Zero);
+                var keyEventArgs = new KeyEventArgs(Keyboard.PrimaryDevice, inputSource, 0, key);
+                keyEventArgs.RoutedEvent = Keyboard.KeyDownEvent;
+                textBox.RaiseEvent(keyEventArgs);
+
+                Assert.AreEqual(0, action.InvokeCount);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(Key.A)]
+        [DataRow(Key.B)]
+        [DataRow(Key.C)]
+        [DataRow(Key.D)]
+        [DataRow(Key.E)]
+        [DataRow(Key.F)]
+        [DataRow(Key.G)]
+        [DataRow(Key.H)]
+        [DataRow(Key.I)]
+        [DataRow(Key.J)]
+        [DataRow(Key.K)]
+        [DataRow(Key.L)]
+        [DataRow(Key.M)]
+        [DataRow(Key.N)]
+        [DataRow(Key.O)]
+        [DataRow(Key.P)]
+        [DataRow(Key.Q)]
+        [DataRow(Key.R)]
+        [DataRow(Key.S)]
+        [DataRow(Key.T)]
+        [DataRow(Key.U)]
+        [DataRow(Key.V)]
+        [DataRow(Key.W)]
+        [DataRow(Key.X)]
+        [DataRow(Key.Y)]
+        [DataRow(Key.Z)]
+        [DataRow(Key.NumPad1)]
+        [DataRow(Key.NumPad2)]
+        [DataRow(Key.NumPad3)]
+        [DataRow(Key.NumPad4)]
+        [DataRow(Key.NumPad5)]
+        [DataRow(Key.NumPad6)]
+        [DataRow(Key.NumPad7)]
+        [DataRow(Key.NumPad8)]
+        [DataRow(Key.NumPad9)]
+        [DataRow(Key.Enter)]
+        [DataRow(Key.Tab)]
+        [DataRow(Key.LeftCtrl)]
+        [DataRow(Key.RightCtrl)]
+        [DataRow(Key.LeftAlt)]
+        [DataRow(Key.RightAlt)]
+        [DataRow(Key.System)]
+        [DataRow(Key.LeftShift)]
+        [DataRow(Key.RightShift)]
         public void KeyTrigger_InvokesActions_WhenKeyIsReleased(Key key)
         {
             var textBox = new TextBox();

--- a/src/Microsoft.Xaml.Behaviors/Input/KeyTrigger.cs
+++ b/src/Microsoft.Xaml.Behaviors/Input/KeyTrigger.cs
@@ -74,7 +74,12 @@ namespace Microsoft.Xaml.Behaviors.Input
         private void OnKeyPress(object sender, KeyEventArgs e)
         {
             bool isKeyMatch = e.Key == this.Key;
-            bool isModifiersMatch = this.Modifiers == ModifierKeys.None ? true : Keyboard.Modifiers == GetActualModifiers(e.Key, this.Modifiers);
+
+            // Get the actual modifiers considering special keys like LeftCtrl, RightCtrl, etc.
+            ModifierKeys actualModifiers = GetActualModifiers();
+
+            // Check if the registered modifiers exactly match the modifiers required by the trigger.
+            bool isModifiersMatch = actualModifiers == this.Modifiers;
 
             if (isKeyMatch && isModifiersMatch)
             {
@@ -82,21 +87,25 @@ namespace Microsoft.Xaml.Behaviors.Input
             }
         }
 
-        private static ModifierKeys GetActualModifiers(Key key, ModifierKeys modifiers)
+        private static ModifierKeys GetActualModifiers()
         {
-            if (key == Key.LeftCtrl || key == Key.RightCtrl)
+            // Explicitly check each modifier key to ensure accurate current state is captured
+            ModifierKeys actualModifiers = ModifierKeys.None;
+
+            if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
             {
-                modifiers |= ModifierKeys.Control;
+                actualModifiers |= ModifierKeys.Control;
             }
-            else if (key == Key.LeftAlt || key == Key.RightAlt || key == Key.System)
+            if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
             {
-                modifiers |= ModifierKeys.Alt;
+                actualModifiers |= ModifierKeys.Shift;
             }
-            else if (key == Key.LeftShift || key == Key.RightShift)
+            if (Keyboard.IsKeyDown(Key.LeftAlt) || Keyboard.IsKeyDown(Key.RightAlt) || Keyboard.IsKeyDown(Key.System))
             {
-                modifiers |= ModifierKeys.Shift;
+                actualModifiers |= ModifierKeys.Alt;
             }
-            return modifiers;
+
+            return actualModifiers;
         }
 
         protected override void OnEvent(EventArgs eventArgs)


### PR DESCRIPTION
Fixed #162 by updating the KeyTrigger logic to look for exact key/modifier key matches.

Since you cannot modify the pressed modifiers in WPF, I was not able to add a unit test for the issues discovered in #162.

I did add an additional test for the scenario when there is a modifier defined on a KeyTrigger, but that modifier is not pressed when pressing a key. In this case, the action should not execute.