### PR TITLE
Fixed package versioning

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -103,7 +103,7 @@ extends:
           inputs:
             vsVersion: $(BuildParameters.vsVersion)
             solution: src\BehaviorsSdk.sln
-            msbuildArgs: /p:SignType=$(SignType) /p:NoWarn=1591 /p:DebugType=full /v:diagnostic
+            msbuildArgs: /p:PublicRelease=$(Build.OfficialRelease) /p:SignType=$(SignType) /p:NoWarn=1591 /p:DebugType=full /v:diagnostic
             configuration: Release
             maximumCpuCount: true
         - task: VSTest@2
@@ -124,7 +124,7 @@ extends:
           displayName: Build NuGet package
           inputs:
             solution: src\Microsoft.Xaml.Behaviors\Microsoft.Xaml.Behaviors.csproj
-            msbuildArgs: /t:Pack /p:SignType=$(SignType) /p:TimestampPackage=$(TimestampPackage) /p:NoWarn=1591 /p:DebugType=full /v:diagnostic
+            msbuildArgs: /t:Pack /p:PublicRelease=$(Build.OfficialRelease) /p:SignType=$(SignType) /p:TimestampPackage=$(TimestampPackage) /p:NoWarn=1591 /p:DebugType=full /v:diagnostic
             configuration: Release
         - task: CopyFiles@2
           displayName: 'Copy Symbols to: $(Pipeline.Workspace)\Symbols'

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "version": "1.1",
   "publicReleaseRefSpec": [
-    "^refs/heads/master$", // we release out of master
+    "^refs/heads/main$", // we release out of main
     "^refs/heads/rel/v\\d+\\.\\d+" // we also release branches starting with vN.N
   ],
   "nugetPackageVersion":{


### PR DESCRIPTION
### Description of Change ###

We need to tell Nerdbank.GitVersioning to use main instead of master for calculations as well as defining PublicRelease=true when making a public release.