### PR TITLE
Use publishFeedCredentials instead of externalEndpoint

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -73,7 +73,7 @@ extends:
             packageParentPath: '$(Build.ArtifactStagingDirectory)\Packages'
             packagesToPush: $(Build.ArtifactStagingDirectory)\Packages\*.nupkg;!$(Build.ArtifactStagingDirectory)\Packages\*.symbols.nupkg
             nuGetFeedType: external
-            externalEndpoint: XamlBehaviors-NuGet.org
+            publishFeedCredentials: XamlBehaviors-NuGet.org
         steps:
         - checkout: self
           clean: true


### PR DESCRIPTION
### Description of Change ###

Correctly use the `publishFeedCredentials` property instead of `externalEndpoint` in order to get
publishing to NuGet.org to work correctly.
