### PR TITLE
Bump nuget.exe used in pipeline to 6.x

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -93,9 +93,9 @@ extends:
             vsVersion: $(BuildParameters.vsVersion)
             performMultiLevelLookup: true
         - task: NuGetToolInstaller@1
-          displayName: Use NuGet 5.8.0
+          displayName: Use NuGet 6.x
           inputs:
-            versionSpec: 5.8.0
+            versionSpec: 6.x
         - task: NuGetCommand@2
           displayName: NuGet restore
         - task: VSBuild@1


### PR DESCRIPTION
5.8.0 is pretty old. Ideally, as long as 6.x works, we should use it.
