### PR TITLE
Fix signing in ADO pipeline

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -118,7 +118,6 @@ extends:
             solution: src\BehaviorsSdk.sln
             msbuildArgs: /p:PublicRelease=$(Build.OfficialRelease) /p:NoWarn=1591 /p:DebugType=full /bl:$(Build.ArtifactStagingDirectory)\Logs\behaviors_sdk_wpf.binlog
             configuration: Release
-            clean: true
         - task: VSTest@2
           displayName: Run Unit Tests
           inputs:


### PR DESCRIPTION
### Description of Change ###

Signing was hanging, probably due to the order of MicroBuildSigningPlugin vs the build tasks. This PR will make the pipeline act more like the working UWP pipeline:
* https://github.com/microsoft/XamlBehaviors/blob/main/azure-pipelines/build.yml