### PR TITLE
Fixes FluidMoveBehavior static dictionary memory leaks

### DIFF
--- a/Test/UnitTests/FluidMoveBehaviorTest.cs
+++ b/Test/UnitTests/FluidMoveBehaviorTest.cs
@@ -13,6 +13,13 @@ using Microsoft.Xaml.Behaviors.Layout;
 
 namespace Microsoft.Xaml.Interactions.UnitTests
 {
+    // Note: these tests touch static dictionaries (FluidMoveBehaviorBase.TagDictionary and
+    // FluidMoveBehavior's storyboard dictionary) and are therefore not safe for parallel
+    // execution. This is not a concern in practice for two reasons:
+    //   1. MSTest does not parallelize tests unless explicitly opted in via
+    //      [assembly: Parallelize] or a .runsettings file, neither of which is present here.
+    //   2. WPF objects are STA-thread-affine; even if parallelism were accidentally enabled,
+    //      the WPF runtime would throw before any dictionary race condition could occur.
     [TestClass]
     public class FluidMoveBehaviorTest
     {
@@ -22,6 +29,16 @@ namespace Microsoft.Xaml.Interactions.UnitTests
             // Clear static dictionaries before each test to avoid cross-test contamination.
             FluidMoveBehaviorBase.TagDictionary.Clear();
             FluidMoveBehavior.ClearStoryboardDictionary();
+        }
+
+        // Two GC.Collect() calls are required: the first collects unreachable objects and
+        // schedules their finalizers; WaitForPendingFinalizers runs those finalizers; the
+        // second collects the now-finalizable objects that were promoted during the first pass.
+        private static void ForceGC()
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
         }
 
         #region TagData WeakReference Tests
@@ -70,9 +87,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
             var tagData = new FluidMoveBehaviorBase.TagData();
             SetChildToEphemeralElement(tagData);
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            ForceGC();
 
             Assert.IsNull(tagData.Child);
         }
@@ -83,9 +98,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
             var tagData = new FluidMoveBehaviorBase.TagData();
             SetParentToEphemeralElement(tagData);
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            ForceGC();
 
             Assert.IsNull(tagData.Parent);
         }
@@ -96,9 +109,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
             var tagData = new FluidMoveBehaviorBase.TagData();
             SetChildToEphemeralElement(tagData);
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            ForceGC();
 
             Assert.IsFalse(tagData.IsAlive);
         }
@@ -126,9 +137,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
             string dataContextKey = "item1";
             AddEphemeralTagDataEntry(dataContextKey);
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            ForceGC();
 
             // The WeakReference should be dead now.
             Assert.IsTrue(FluidMoveBehaviorBase.TagDictionary.ContainsKey(dataContextKey),
@@ -260,9 +269,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
             FluidMoveBehavior.InjectStoryboardEntry(dataContextKey, storyboard);
             AddEphemeralTagDataEntry(dataContextKey);
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            ForceGC();
 
             FluidMoveBehavior.PurgeDeadStoryboards();
 

--- a/Test/UnitTests/FluidMoveBehaviorTest.cs
+++ b/Test/UnitTests/FluidMoveBehaviorTest.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Xaml.Interactions.UnitTests
         {
             // Clear static dictionaries before each test to avoid cross-test contamination.
             FluidMoveBehaviorBase.TagDictionary.Clear();
-            FluidMoveBehavior.TransitionStoryboardDictionary.Clear();
         }
 
         #region TagData WeakReference Tests
@@ -148,8 +147,8 @@ namespace Microsoft.Xaml.Interactions.UnitTests
         public void TagDictionary_PurgesEntryWhenElementKeyUnloaded()
         {
             // Simulate an Element-type tag: the key IS the FrameworkElement.
-            // An unloaded element (never added to visual tree) has IsLoaded = false.
-            var element = new Button(); // not added to any visual tree, so IsLoaded = false
+            // An element never added to a visual tree has IsLoaded == false.
+            var element = new Button();
             var tagData = new FluidMoveBehaviorBase.TagData
             {
                 Child = element,
@@ -170,7 +169,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
         [TestMethod]
         public void TagDictionary_DoesNotPurgeAliveEntries()
         {
-            // Entry with a live child and non-element key should survive purge.
+            // Entry with a live child and a non-element key should survive purge.
             string key = "alive-item";
             var element = new Button();
             var tagData = new FluidMoveBehaviorBase.TagData
@@ -213,21 +212,18 @@ namespace Microsoft.Xaml.Interactions.UnitTests
             List<object> deadTags = null;
             foreach (KeyValuePair<object, FluidMoveBehaviorBase.TagData> pair in FluidMoveBehaviorBase.TagDictionary)
             {
-                if (!pair.Value.IsAlive || (pair.Key is FrameworkElement fe && !fe.IsLoaded))
+                bool isDead = !pair.Value.IsAlive ||
+                              (pair.Key is FrameworkElement fe && !fe.IsLoaded);
+                if (isDead)
                 {
-                    if (deadTags == null)
-                    {
-                        deadTags = new List<object>();
-                    }
+                    if (deadTags == null) deadTags = new List<object>();
                     deadTags.Add(pair.Key);
                 }
             }
             if (deadTags != null)
             {
                 foreach (object tag in deadTags)
-                {
                     FluidMoveBehaviorBase.TagDictionary.Remove(tag);
-                }
             }
         }
 
@@ -239,15 +235,15 @@ namespace Microsoft.Xaml.Interactions.UnitTests
         public void PurgeDeadStoryboards_RemovesEntryForUnloadedElementKey()
         {
             // An unloaded element key should be purged from the storyboard dictionary.
-            var element = new Button(); // not in visual tree, IsLoaded = false
+            var element = new Button(); // not in visual tree, IsLoaded == false
             var storyboard = new Storyboard();
 
-            FluidMoveBehavior.TransitionStoryboardDictionary.Add(element, storyboard);
-            Assert.IsTrue(FluidMoveBehavior.TransitionStoryboardDictionary.ContainsKey(element));
+            FluidMoveBehavior.InjectStoryboardEntry(element, storyboard);
+            Assert.IsTrue(FluidMoveBehavior.StoryboardDictionaryContainsKey(element));
 
             FluidMoveBehavior.PurgeDeadStoryboards();
 
-            Assert.IsFalse(FluidMoveBehavior.TransitionStoryboardDictionary.ContainsKey(element),
+            Assert.IsFalse(FluidMoveBehavior.StoryboardDictionaryContainsKey(element),
                 "Storyboard entry with unloaded element key should be removed after purge.");
         }
 
@@ -259,7 +255,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
             string dataContextKey = "dc-item";
             var storyboard = new Storyboard();
 
-            FluidMoveBehavior.TransitionStoryboardDictionary.Add(dataContextKey, storyboard);
+            FluidMoveBehavior.InjectStoryboardEntry(dataContextKey, storyboard);
             AddEphemeralTagDataEntry(dataContextKey);
 
             GC.Collect();
@@ -268,8 +264,25 @@ namespace Microsoft.Xaml.Interactions.UnitTests
 
             FluidMoveBehavior.PurgeDeadStoryboards();
 
-            Assert.IsFalse(FluidMoveBehavior.TransitionStoryboardDictionary.ContainsKey(dataContextKey),
+            Assert.IsFalse(FluidMoveBehavior.StoryboardDictionaryContainsKey(dataContextKey),
                 "Storyboard entry with dead child in TagDictionary should be removed after purge.");
+        }
+
+        [TestMethod]
+        public void PurgeDeadStoryboards_RemovesOrphanedDataContextKey()
+        {
+            // A storyboard entry whose key has no corresponding TagDictionary entry
+            // should be removed as an orphan.
+            string orphanKey = "orphan-dc";
+            var storyboard = new Storyboard();
+
+            FluidMoveBehavior.InjectStoryboardEntry(orphanKey, storyboard);
+
+            // No TagDictionary entry for this key.
+            FluidMoveBehavior.PurgeDeadStoryboards();
+
+            Assert.IsFalse(FluidMoveBehavior.StoryboardDictionaryContainsKey(orphanKey),
+                "Storyboard entry with no corresponding TagDictionary entry should be removed.");
         }
 
         #endregion

--- a/Test/UnitTests/FluidMoveBehaviorTest.cs
+++ b/Test/UnitTests/FluidMoveBehaviorTest.cs
@@ -1,0 +1,277 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media.Animation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xaml.Behaviors.Layout;
+
+namespace Microsoft.Xaml.Interactions.UnitTests
+{
+    [TestClass]
+    public class FluidMoveBehaviorTest
+    {
+        [TestInitialize]
+        public void Setup()
+        {
+            // Clear static dictionaries before each test to avoid cross-test contamination.
+            FluidMoveBehaviorBase.TagDictionary.Clear();
+            FluidMoveBehavior.TransitionStoryboardDictionary.Clear();
+        }
+
+        #region TagData WeakReference Tests
+
+        [TestMethod]
+        public void TagData_Child_ReturnsElementWhileAlive()
+        {
+            var element = new Button();
+            var tagData = new FluidMoveBehaviorBase.TagData { Child = element };
+
+            Assert.AreSame(element, tagData.Child);
+        }
+
+        [TestMethod]
+        public void TagData_Parent_ReturnsElementWhileAlive()
+        {
+            var element = new StackPanel();
+            var tagData = new FluidMoveBehaviorBase.TagData { Parent = element };
+
+            Assert.AreSame(element, tagData.Parent);
+        }
+
+        [TestMethod]
+        public void TagData_IsAlive_ReturnsTrueWhileChildAlive()
+        {
+            var element = new Button();
+            var tagData = new FluidMoveBehaviorBase.TagData { Child = element };
+
+            Assert.IsTrue(tagData.IsAlive);
+            GC.KeepAlive(element);
+        }
+
+        [TestMethod]
+        public void TagData_SetChildNull_ReturnsNull()
+        {
+            var tagData = new FluidMoveBehaviorBase.TagData { Child = new Button() };
+            tagData.Child = null;
+
+            Assert.IsNull(tagData.Child);
+            Assert.IsFalse(tagData.IsAlive);
+        }
+
+        [TestMethod]
+        public void TagData_Child_ReturnsNullAfterGC()
+        {
+            var tagData = new FluidMoveBehaviorBase.TagData();
+            SetChildToEphemeralElement(tagData);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.IsNull(tagData.Child);
+        }
+
+        [TestMethod]
+        public void TagData_Parent_ReturnsNullAfterGC()
+        {
+            var tagData = new FluidMoveBehaviorBase.TagData();
+            SetParentToEphemeralElement(tagData);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.IsNull(tagData.Parent);
+        }
+
+        [TestMethod]
+        public void TagData_IsAlive_ReturnsFalseAfterGC()
+        {
+            var tagData = new FluidMoveBehaviorBase.TagData();
+            SetChildToEphemeralElement(tagData);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.IsFalse(tagData.IsAlive);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void SetChildToEphemeralElement(FluidMoveBehaviorBase.TagData tagData)
+        {
+            tagData.Child = new Button();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void SetParentToEphemeralElement(FluidMoveBehaviorBase.TagData tagData)
+        {
+            tagData.Parent = new StackPanel();
+        }
+
+        #endregion
+
+        #region TagDictionary Purge Tests
+
+        [TestMethod]
+        public void TagDictionary_PurgesEntryWhenChildCollected()
+        {
+            // Simulate a DataContext-type tag: the key is a data object, the element is in the value.
+            string dataContextKey = "item1";
+            AddEphemeralTagDataEntry(dataContextKey);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            // The WeakReference should be dead now.
+            Assert.IsTrue(FluidMoveBehaviorBase.TagDictionary.ContainsKey(dataContextKey),
+                "Entry should still exist in dictionary before purge.");
+
+            FluidMoveBehaviorBase.TagData td;
+            FluidMoveBehaviorBase.TagDictionary.TryGetValue(dataContextKey, out td);
+            Assert.IsFalse(td.IsAlive, "Child should no longer be alive after GC.");
+
+            // Simulate purge: remove dead entries.
+            PurgeDeadTagEntries();
+
+            Assert.IsFalse(FluidMoveBehaviorBase.TagDictionary.ContainsKey(dataContextKey),
+                "Entry should be removed after purge.");
+        }
+
+        [TestMethod]
+        public void TagDictionary_PurgesEntryWhenElementKeyUnloaded()
+        {
+            // Simulate an Element-type tag: the key IS the FrameworkElement.
+            // An unloaded element (never added to visual tree) has IsLoaded = false.
+            var element = new Button(); // not added to any visual tree, so IsLoaded = false
+            var tagData = new FluidMoveBehaviorBase.TagData
+            {
+                Child = element,
+                Parent = null,
+                ParentRect = Rect.Empty,
+                AppRect = Rect.Empty,
+            };
+
+            FluidMoveBehaviorBase.TagDictionary.Add(element, tagData);
+            Assert.IsFalse(element.IsLoaded, "Element should not be loaded (not in visual tree).");
+
+            PurgeDeadTagEntries();
+
+            Assert.IsFalse(FluidMoveBehaviorBase.TagDictionary.ContainsKey(element),
+                "Entry with unloaded element key should be removed after purge.");
+        }
+
+        [TestMethod]
+        public void TagDictionary_DoesNotPurgeAliveEntries()
+        {
+            // Entry with a live child and non-element key should survive purge.
+            string key = "alive-item";
+            var element = new Button();
+            var tagData = new FluidMoveBehaviorBase.TagData
+            {
+                Child = element,
+                Parent = null,
+                ParentRect = Rect.Empty,
+                AppRect = Rect.Empty,
+            };
+
+            FluidMoveBehaviorBase.TagDictionary.Add(key, tagData);
+
+            PurgeDeadTagEntries();
+
+            Assert.IsTrue(FluidMoveBehaviorBase.TagDictionary.ContainsKey(key),
+                "Entry with alive child and non-element key should not be purged.");
+
+            GC.KeepAlive(element);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void AddEphemeralTagDataEntry(string key)
+        {
+            var element = new Button();
+            var tagData = new FluidMoveBehaviorBase.TagData
+            {
+                Child = element,
+                Parent = null,
+                ParentRect = Rect.Empty,
+                AppRect = Rect.Empty,
+            };
+            FluidMoveBehaviorBase.TagDictionary.Add(key, tagData);
+        }
+
+        /// <summary>
+        /// Simulates the purge logic from the LayoutUpdated handler.
+        /// </summary>
+        private static void PurgeDeadTagEntries()
+        {
+            List<object> deadTags = null;
+            foreach (KeyValuePair<object, FluidMoveBehaviorBase.TagData> pair in FluidMoveBehaviorBase.TagDictionary)
+            {
+                if (!pair.Value.IsAlive || (pair.Key is FrameworkElement fe && !fe.IsLoaded))
+                {
+                    if (deadTags == null)
+                    {
+                        deadTags = new List<object>();
+                    }
+                    deadTags.Add(pair.Key);
+                }
+            }
+            if (deadTags != null)
+            {
+                foreach (object tag in deadTags)
+                {
+                    FluidMoveBehaviorBase.TagDictionary.Remove(tag);
+                }
+            }
+        }
+
+        #endregion
+
+        #region TransitionStoryboardDictionary Purge Tests
+
+        [TestMethod]
+        public void PurgeDeadStoryboards_RemovesEntryForUnloadedElementKey()
+        {
+            // An unloaded element key should be purged from the storyboard dictionary.
+            var element = new Button(); // not in visual tree, IsLoaded = false
+            var storyboard = new Storyboard();
+
+            FluidMoveBehavior.TransitionStoryboardDictionary.Add(element, storyboard);
+            Assert.IsTrue(FluidMoveBehavior.TransitionStoryboardDictionary.ContainsKey(element));
+
+            FluidMoveBehavior.PurgeDeadStoryboards();
+
+            Assert.IsFalse(FluidMoveBehavior.TransitionStoryboardDictionary.ContainsKey(element),
+                "Storyboard entry with unloaded element key should be removed after purge.");
+        }
+
+        [TestMethod]
+        public void PurgeDeadStoryboards_RemovesEntryForDataContextKeyWithDeadChild()
+        {
+            // DataContext-type key: the key is a data object, not a FrameworkElement.
+            // The storyboard should be purged when the TagDictionary entry's child is dead.
+            string dataContextKey = "dc-item";
+            var storyboard = new Storyboard();
+
+            FluidMoveBehavior.TransitionStoryboardDictionary.Add(dataContextKey, storyboard);
+            AddEphemeralTagDataEntry(dataContextKey);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            FluidMoveBehavior.PurgeDeadStoryboards();
+
+            Assert.IsFalse(FluidMoveBehavior.TransitionStoryboardDictionary.ContainsKey(dataContextKey),
+                "Storyboard entry with dead child in TagDictionary should be removed after purge.");
+        }
+
+        #endregion
+    }
+}

--- a/Test/UnitTests/FluidMoveBehaviorTest.cs
+++ b/Test/UnitTests/FluidMoveBehaviorTest.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Animation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xaml.Behaviors;
 using Microsoft.Xaml.Behaviors.Layout;
 
 namespace Microsoft.Xaml.Interactions.UnitTests
@@ -20,6 +21,7 @@ namespace Microsoft.Xaml.Interactions.UnitTests
         {
             // Clear static dictionaries before each test to avoid cross-test contamination.
             FluidMoveBehaviorBase.TagDictionary.Clear();
+            FluidMoveBehavior.ClearStoryboardDictionary();
         }
 
         #region TagData WeakReference Tests
@@ -283,6 +285,185 @@ namespace Microsoft.Xaml.Interactions.UnitTests
 
             Assert.IsFalse(FluidMoveBehavior.StoryboardDictionaryContainsKey(orphanKey),
                 "Storyboard entry with no corresponding TagDictionary entry should be removed.");
+        }
+
+        #endregion
+
+        #region Retention Tests (end-to-end with real visual tree)
+
+        /// <summary>
+        /// Pumps the WPF dispatcher so that layout, data binding, and Loaded/Unloaded events
+        /// are processed. Calls DispatcherHelper.ClearFrames which pushes a frame until SystemIdle.
+        /// </summary>
+        private static void PumpDispatcher()
+        {
+            DispatcherHelper.ClearFrames(System.Windows.Threading.Dispatcher.CurrentDispatcher);
+        }
+
+        [TestMethod]
+        public void Retention_ElementTypeEntries_RemovedAfterChildRemovedFromPanel()
+        {
+            FluidMoveBehaviorBase.ResetPurgeThrottle();
+
+            var window = new Window { Width = 200, Height = 200 };
+            var panel = new StackPanel();
+            var behavior = new FluidMoveBehavior
+            {
+                AppliesTo = FluidMoveScope.Children,
+                Duration = new Duration(TimeSpan.FromMilliseconds(0))
+            };
+            Interaction.GetBehaviors(panel).Add(behavior);
+            window.Content = panel;
+
+            var child1 = new Button { Width = 50, Height = 50 };
+            var child2 = new Button { Width = 50, Height = 50 };
+            panel.Children.Add(child1);
+            panel.Children.Add(child2);
+
+            try
+            {
+                window.Show();
+                PumpDispatcher();
+
+                // Entries should exist for both children (element-type keys).
+                Assert.IsTrue(FluidMoveBehaviorBase.TagDictionary.ContainsKey(child1),
+                    "child1 should be tracked after layout.");
+                Assert.IsTrue(FluidMoveBehaviorBase.TagDictionary.ContainsKey(child2),
+                    "child2 should be tracked after layout.");
+
+                // Remove child1 from the panel.
+                panel.Children.Remove(child1);
+
+                // First pump processes: layout pass + LayoutUpdated (Render priority),
+                // then Unloaded fires (Loaded priority, lower) setting IsLoaded = false.
+                // The purge runs during the first LayoutUpdated but misses child1 because
+                // IsLoaded is still true at Render priority. After this pump, IsLoaded is false.
+                PumpDispatcher();
+
+                // Reset throttle and force another layout pass so the purge runs again,
+                // this time seeing IsLoaded == false.
+                FluidMoveBehaviorBase.ResetPurgeThrottle();
+                panel.InvalidateArrange();
+                PumpDispatcher();
+
+                Assert.IsFalse(FluidMoveBehaviorBase.TagDictionary.ContainsKey(child1),
+                    "Removed child's entry should be purged from TagDictionary.");
+                Assert.IsTrue(FluidMoveBehaviorBase.TagDictionary.ContainsKey(child2),
+                    "Remaining child's entry should survive.");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [TestMethod]
+        public void Retention_ElementTypeEntries_SurviveReparenting()
+        {
+            FluidMoveBehaviorBase.ResetPurgeThrottle();
+
+            var window = new Window { Width = 300, Height = 200 };
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition());
+            grid.ColumnDefinitions.Add(new ColumnDefinition());
+
+            var panelA = new StackPanel();
+            var panelB = new StackPanel();
+            Grid.SetColumn(panelA, 0);
+            Grid.SetColumn(panelB, 1);
+            grid.Children.Add(panelA);
+            grid.Children.Add(panelB);
+
+            var behaviorA = new FluidMoveBehavior
+            {
+                AppliesTo = FluidMoveScope.Children,
+                Duration = new Duration(TimeSpan.FromMilliseconds(0))
+            };
+            var behaviorB = new FluidMoveBehavior
+            {
+                AppliesTo = FluidMoveScope.Children,
+                Duration = new Duration(TimeSpan.FromMilliseconds(0))
+            };
+            Interaction.GetBehaviors(panelA).Add(behaviorA);
+            Interaction.GetBehaviors(panelB).Add(behaviorB);
+
+            window.Content = grid;
+
+            var child = new Button { Width = 50, Height = 50 };
+            panelA.Children.Add(child);
+
+            try
+            {
+                window.Show();
+                PumpDispatcher();
+
+                Assert.IsTrue(FluidMoveBehaviorBase.TagDictionary.ContainsKey(child),
+                    "child should be tracked in panelA.");
+
+                // Reparent: move child from panelA to panelB.
+                panelA.Children.Remove(child);
+                panelB.Children.Add(child);
+
+                PumpDispatcher();
+                FluidMoveBehaviorBase.ResetPurgeThrottle();
+                panelB.InvalidateArrange();
+                PumpDispatcher();
+
+                // The entry should survive reparenting — the child is loaded in panelB.
+                Assert.IsTrue(FluidMoveBehaviorBase.TagDictionary.ContainsKey(child),
+                    "child's entry should survive reparenting (still loaded in panelB).");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [TestMethod]
+        public void Retention_AllChildrenRemoved_EntriesEventuallyPurged()
+        {
+            FluidMoveBehaviorBase.ResetPurgeThrottle();
+
+            var window = new Window { Width = 200, Height = 200 };
+            var panel = new StackPanel();
+            var behavior = new FluidMoveBehavior
+            {
+                AppliesTo = FluidMoveScope.Children,
+                Duration = new Duration(TimeSpan.FromMilliseconds(0))
+            };
+            Interaction.GetBehaviors(panel).Add(behavior);
+            window.Content = panel;
+
+            var child1 = new Button { Width = 50, Height = 50 };
+            var child2 = new Button { Width = 50, Height = 50 };
+            panel.Children.Add(child1);
+            panel.Children.Add(child2);
+
+            try
+            {
+                window.Show();
+                PumpDispatcher();
+
+                int initialCount = FluidMoveBehaviorBase.TagDictionary.Count;
+                Assert.IsTrue(initialCount >= 2, "Should have at least 2 entries.");
+
+                // Remove ALL children.
+                panel.Children.Clear();
+
+                PumpDispatcher(); // processes layout + Unloaded
+                FluidMoveBehaviorBase.ResetPurgeThrottle();
+                panel.InvalidateArrange();
+                PumpDispatcher(); // purge now sees IsLoaded == false
+
+                Assert.IsFalse(FluidMoveBehaviorBase.TagDictionary.ContainsKey(child1),
+                    "child1 entry should be purged after removal.");
+                Assert.IsFalse(FluidMoveBehaviorBase.TagDictionary.ContainsKey(child2),
+                    "child2 entry should be purged after removal.");
+            }
+            finally
+            {
+                window.Close();
+            }
         }
 
         #endregion

--- a/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
+++ b/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
@@ -153,10 +153,9 @@ namespace Microsoft.Xaml.Behaviors.Layout
                 return;
             }
 
-            // Periodically purge dead entries from both static dictionaries.
-            // An entry is dead if:
-            //   - The child WeakReference has been collected (DataContext-type tags)
-            //   - The key is a FrameworkElement that is no longer loaded (Element-type tags)
+            // Throttled dead-entry purge. Removes entries whose tracked element has been
+            // garbage-collected (IsAlive == false) or removed from the visual tree (IsLoaded == false).
+            // Running on every LayoutUpdated would be too expensive for panels with many children.
             if (DateTime.Now - lastPurgeTime >= purgeInterval)
             {
                 lastPurgeTime = DateTime.Now;
@@ -164,12 +163,13 @@ namespace Microsoft.Xaml.Behaviors.Layout
                 List<object> deadTags = null;
                 foreach (KeyValuePair<object, TagData> pair in TagDictionary)
                 {
-                    if (!pair.Value.IsAlive || (pair.Key is FrameworkElement fe && !fe.IsLoaded))
+                    // DataContext-type key: child WeakRef dead means the element is gone.
+                    // Element-type key: the key IS the FrameworkElement; IsLoaded==false means removed from tree.
+                    bool isDead = !pair.Value.IsAlive ||
+                                  (pair.Key is FrameworkElement fe && !fe.IsLoaded);
+                    if (isDead)
                     {
-                        if (deadTags == null)
-                        {
-                            deadTags = new List<object>();
-                        }
+                        if (deadTags == null) deadTags = new List<object>();
                         deadTags.Add(pair.Key);
                     }
                 }
@@ -177,9 +177,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
                 if (deadTags != null)
                 {
                     foreach (object tag in deadTags)
-                    {
                         TagDictionary.Remove(tag);
-                    }
                 }
 
                 FluidMoveBehavior.PurgeDeadStoryboards();
@@ -303,6 +301,13 @@ namespace Microsoft.Xaml.Behaviors.Layout
         {
             TagData tagData;
             bool gotData = TagDictionary.TryGetValue(tag, out tagData);
+
+            // Eagerly remove entries with dead weak references rather than waiting for the periodic purge.
+            if (gotData && !tagData.IsAlive)
+            {
+                gotData = false;
+                TagDictionary.Remove(tag);
+            }
 
             if (!gotData)
             {
@@ -431,51 +436,58 @@ namespace Microsoft.Xaml.Behaviors.Layout
         private static bool GetHasTransformWrapper(DependencyObject obj) { return (bool)obj.GetValue(hasTransformWrapperProperty); }
         private static void SetHasTransformWrapper(DependencyObject obj, bool value) { obj.SetValue(hasTransformWrapperProperty, value); }
 
-        internal static Dictionary<object, Storyboard> TransitionStoryboardDictionary = new Dictionary<object, Storyboard>();
+        private static Dictionary<object, Storyboard> transitionStoryboardDictionary = new Dictionary<object, Storyboard>();
 
         /// <summary>
-        /// Removes entries from transitionStoryboardDictionary whose associated elements are no longer alive.
+        /// Removes entries from <see cref="transitionStoryboardDictionary"/> whose elements have left
+        /// the visual tree or whose tracked child has been garbage-collected.
         /// </summary>
         internal static void PurgeDeadStoryboards()
         {
             List<object> deadTags = null;
-            foreach (var pair in TransitionStoryboardDictionary)
+            foreach (KeyValuePair<object, Storyboard> pair in transitionStoryboardDictionary)
             {
-                bool isDead = false;
-
-                // Element-type keys: the key is a FrameworkElement
-                if (pair.Key is FrameworkElement fe && !fe.IsLoaded)
+                bool isDead;
+                if (pair.Key is FrameworkElement fe)
                 {
-                    isDead = true;
+                    // Element-type key: safe to remove when the element is no longer in the tree.
+                    isDead = !fe.IsLoaded;
                 }
-                // DataContext-type keys: cross-check TagDictionary to see if the element is still alive
-                else if (TagDictionary.TryGetValue(pair.Key, out var td) && !td.IsAlive)
+                else
                 {
-                    isDead = true;
+                    // DataContext-type key: remove when the corresponding TagDictionary entry is dead.
+                    TagData tagData;
+                    isDead = !TagDictionary.TryGetValue(pair.Key, out tagData) || !tagData.IsAlive;
                 }
 
                 if (isDead)
                 {
-                    if (deadTags == null)
-                    {
-                        deadTags = new List<object>();
-                    }
+                    if (deadTags == null) deadTags = new List<object>();
                     deadTags.Add(pair.Key);
                 }
             }
+
             if (deadTags != null)
             {
                 foreach (object tag in deadTags)
                 {
                     Storyboard sb;
-                    if (TransitionStoryboardDictionary.TryGetValue(tag, out sb))
+                    if (transitionStoryboardDictionary.TryGetValue(tag, out sb))
                     {
                         sb.Stop();
-                        TransitionStoryboardDictionary.Remove(tag);
+                        transitionStoryboardDictionary.Remove(tag);
                     }
                 }
             }
         }
+
+        // Test helpers — allow unit tests to inject and query transitionStoryboardDictionary
+        // without exposing it publicly. Gated by InternalsVisibleTo in AssemblyInfo.cs.
+        internal static void InjectStoryboardEntry(object key, Storyboard storyboard)
+            => transitionStoryboardDictionary[key] = storyboard;
+
+        internal static bool StoryboardDictionaryContainsKey(object key)
+            => transitionStoryboardDictionary.ContainsKey(key);
 
         protected override bool ShouldSkipInitialLayout
         {
@@ -529,9 +541,9 @@ namespace Microsoft.Xaml.Behaviors.Layout
         {
             object tag = GetIdentityTag(child) ?? child;
             Storyboard storyboard;
-            if (TransitionStoryboardDictionary.TryGetValue(tag, out storyboard))
+            if (transitionStoryboardDictionary.TryGetValue(tag, out storyboard))
             {
-                TransitionStoryboardDictionary.Remove(tag);
+                transitionStoryboardDictionary.Remove(tag);
                 storyboard.Stop();
             }
         }
@@ -548,6 +560,13 @@ namespace Microsoft.Xaml.Behaviors.Layout
             // Locate the previous tag, and the parent-relative previous rect. The previous rect is computed using the app-relative rect if switching parents.
             // Note that we do not use the app-relative rect all time time, because when the parent itself moves, it accounts for all the motion and we do not have to.
             bool gotData = TagDictionary.TryGetValue(tag, out tagData);
+
+            // Eagerly remove entries with dead weak references rather than waiting for the periodic purge.
+            if (gotData && !tagData.IsAlive)
+            {
+                gotData = false;
+                TagDictionary.Remove(tag);
+            }
 
             // if spawn point has changed then throw away the old one
             if (gotData && tagData.InitialTag != initialTag)
@@ -586,7 +605,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
             FrameworkElement originalChild = child;
 
             if ((!FluidMoveBehavior.IsEmptyRect(previousRect) && !FluidMoveBehavior.IsEmptyRect(newTagData.ParentRect)) && (!IsClose(previousRect.Left, newTagData.ParentRect.Left) || !IsClose(previousRect.Top, newTagData.ParentRect.Top)) ||
-                (child != tagData.Child && TransitionStoryboardDictionary.ContainsKey(tag)))
+                (child != tagData.Child && transitionStoryboardDictionary.ContainsKey(tag)))
             {
                 Rect currentRect = previousRect;
                 bool forceFloatAbove = false;
@@ -594,7 +613,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
                 // If this element was animating before, append its current transform to the start position and kill the old animation.
                 // Note that in an overlay scenario, the animation is on the image in the overlay.
                 Storyboard oldTransitionStoryboard = null;
-                if (TransitionStoryboardDictionary.TryGetValue(tag, out oldTransitionStoryboard))
+                if (transitionStoryboardDictionary.TryGetValue(tag, out oldTransitionStoryboard))
                 {
                     FrameworkElement previousChild = tagData.Child; // cache: may be null if GC'd
 
@@ -620,7 +639,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
                         currentRect = transform.TransformBounds(currentRect);
                     }
 
-                    TransitionStoryboardDictionary.Remove(tag);
+                    transitionStoryboardDictionary.Remove(tag);
                     oldTransitionStoryboard.Stop();
                     oldTransitionStoryboard = null;
 
@@ -681,14 +700,14 @@ namespace Microsoft.Xaml.Behaviors.Layout
                 Storyboard transitionStoryboard = CreateTransitionStoryboard(child, usingBeforeLoaded, ref parentRect, ref currentRect);
 
                 // Put this storyboard in the running dictionary so we can detect reentrancy
-                TransitionStoryboardDictionary.Add(tag, transitionStoryboard);
+                transitionStoryboardDictionary.Add(tag, transitionStoryboard);
 
                 transitionStoryboard.Completed += delegate (object sender, EventArgs e)
                 {
                     Storyboard currentlyRunningStoryboard;
-                    if (TransitionStoryboardDictionary.TryGetValue(tag, out currentlyRunningStoryboard) && currentlyRunningStoryboard == transitionStoryboard)
+                    if (transitionStoryboardDictionary.TryGetValue(tag, out currentlyRunningStoryboard) && currentlyRunningStoryboard == transitionStoryboard)
                     {
-                        TransitionStoryboardDictionary.Remove(tag);
+                        transitionStoryboardDictionary.Remove(tag);
                         transitionStoryboard.Stop();
                         RemoveTransform(child);
                         child.InvalidateMeasure();

--- a/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
+++ b/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
             /// <summary>
             /// Returns true if the Child WeakReference is still alive.
             /// </summary>
-            public bool IsAlive => _child != null && _child.TryGetTarget(out _);
+            public bool IsAlive => _child != null;
         }
 
         internal static Dictionary<object, TagData> TagDictionary = new Dictionary<object, TagData>();
@@ -178,7 +178,10 @@ namespace Microsoft.Xaml.Behaviors.Layout
                                   (pair.Key is FrameworkElement fe && !fe.IsLoaded);
                     if (isDead)
                     {
-                        if (deadTags == null) deadTags = new List<object>();
+                        if (deadTags == null)
+                        {
+                            deadTags = new List<object>();
+                        }
                         deadTags.Add(pair.Key);
                     }
                 }
@@ -186,7 +189,9 @@ namespace Microsoft.Xaml.Behaviors.Layout
                 if (deadTags != null)
                 {
                     foreach (object tag in deadTags)
+                    {
                         TagDictionary.Remove(tag);
+                    }
                 }
 
                 FluidMoveBehavior.PurgeDeadStoryboards();
@@ -225,7 +230,6 @@ namespace Microsoft.Xaml.Behaviors.Layout
             newTagData.Parent = VisualTreeHelper.GetParent(child) as FrameworkElement;
             newTagData.ParentRect = ExtendedVisualStateManager.GetLayoutRect(child);
             newTagData.Child = child;
-
 
             try
             {
@@ -471,7 +475,10 @@ namespace Microsoft.Xaml.Behaviors.Layout
 
                 if (isDead)
                 {
-                    if (deadTags == null) deadTags = new List<object>();
+                    if (deadTags == null)
+                    {
+                        deadTags = new List<object>();
+                    }
                     deadTags.Add(pair.Key);
                 }
             }
@@ -741,7 +748,6 @@ namespace Microsoft.Xaml.Behaviors.Layout
             tagData.AppRect = newTagData.AppRect;
             tagData.Parent = newTagData.Parent;
             tagData.Child = newTagData.Child;
-
         }
 
         private Storyboard CreateTransitionStoryboard(FrameworkElement child, bool usingBeforeLoaded, ref Rect layoutRect, ref Rect currentRect)

--- a/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
+++ b/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
@@ -134,6 +134,15 @@ namespace Microsoft.Xaml.Behaviors.Layout
         private static DateTime lastPurgeTime = DateTime.MinValue;
         private static readonly TimeSpan purgeInterval = TimeSpan.FromSeconds(1.0);
 
+        /// <summary>
+        /// Resets the purge throttle so the next LayoutUpdated pass triggers an immediate purge.
+        /// Intended for unit tests only.
+        /// </summary>
+        internal static void ResetPurgeThrottle()
+        {
+            lastPurgeTime = DateTime.MinValue;
+        }
+
         protected override void OnAttached()
         {
             base.OnAttached();
@@ -488,6 +497,9 @@ namespace Microsoft.Xaml.Behaviors.Layout
 
         internal static bool StoryboardDictionaryContainsKey(object key)
             => transitionStoryboardDictionary.ContainsKey(key);
+
+        internal static void ClearStoryboardDictionary()
+            => transitionStoryboardDictionary.Clear();
 
         protected override bool ShouldSkipInitialLayout
         {

--- a/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
+++ b/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
             /// <summary>
             /// Returns true if the Child WeakReference is still alive.
             /// </summary>
-            public bool IsAlive => _child != null;
+            public bool IsAlive => _child != null && _child.TryGetTarget(out _);
         }
 
         internal static Dictionary<object, TagData> TagDictionary = new Dictionary<object, TagData>();

--- a/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
+++ b/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
@@ -98,23 +98,41 @@ namespace Microsoft.Xaml.Behaviors.Layout
 
         /// <summary>
         /// Private structure that stores all relevant data pertaining to a tagged item.
+        /// Child and Parent are stored as WeakReferences to avoid leaking FrameworkElements
+        /// in the static TagDictionary when elements are removed from the visual tree.
         /// </summary>
         internal class TagData
         {
-            public FrameworkElement Child { get; set; } // the element
-            public FrameworkElement Parent { get; set; }// the parent
+            private WeakReference<FrameworkElement> _child;
+            private WeakReference<FrameworkElement> _parent;
+
+            public FrameworkElement Child
+            {
+                get => _child != null && _child.TryGetTarget(out var c) ? c : null;
+                set => _child = value != null ? new WeakReference<FrameworkElement>(value) : null;
+            }
+
+            public FrameworkElement Parent
+            {
+                get => _parent != null && _parent.TryGetTarget(out var p) ? p : null;
+                set => _parent = value != null ? new WeakReference<FrameworkElement>(value) : null;
+            }
+
             public Rect ParentRect { get; set; }        // the parent-relative rect
             public Rect AppRect { get; set; }           // the app-relative rect
-            public DateTime Timestamp { get; set; }     // the last time we saw the element
             public object InitialTag { get; set; }      // the tag to spawn from
+
+            /// <summary>
+            /// Returns true if the Child WeakReference is still alive.
+            /// </summary>
+            public bool IsAlive => _child != null && _child.TryGetTarget(out _);
         }
 
         internal static Dictionary<object, TagData> TagDictionary = new Dictionary<object, TagData>();
 
-        // timer data to help purge objects we should no longer be tracking
-        private static DateTime nextToLastPurgeTick = DateTime.MinValue;
-        private static DateTime lastPurgeTick = DateTime.MinValue;
-        private static TimeSpan minTickDelta = TimeSpan.FromSeconds(0.5);
+        // throttle data for the dead-entry purge scan
+        private static DateTime lastPurgeTime = DateTime.MinValue;
+        private static readonly TimeSpan purgeInterval = TimeSpan.FromSeconds(1.0);
 
         protected override void OnAttached()
         {
@@ -135,19 +153,18 @@ namespace Microsoft.Xaml.Behaviors.Layout
                 return;
             }
 
-            // if it's been long enough since our last purge, then let's kick one off. Since we can't control how often layout runs, and some
-            // objects could reappear on the very next layout pass, we'll purge any tag who hasn't been seen since the purge tick before that.
-            //
-            // If we got a notification when elements were deleted, we would maintain a far shorter list of tags whose FEs were deleted since the last purge.
-            // 
-            // We might also be able to use a WeakReference solution here, but this one is pretty cheap as it only runs when Layout is running anyway.
-            if (DateTime.Now - lastPurgeTick >= minTickDelta)
+            // Periodically purge dead entries from both static dictionaries.
+            // An entry is dead if:
+            //   - The child WeakReference has been collected (DataContext-type tags)
+            //   - The key is a FrameworkElement that is no longer loaded (Element-type tags)
+            if (DateTime.Now - lastPurgeTime >= purgeInterval)
             {
-                List<object> deadTags = null;
+                lastPurgeTime = DateTime.Now;
 
+                List<object> deadTags = null;
                 foreach (KeyValuePair<object, TagData> pair in TagDictionary)
                 {
-                    if (pair.Value.Timestamp < nextToLastPurgeTick)
+                    if (!pair.Value.IsAlive || (pair.Key is FrameworkElement fe && !fe.IsLoaded))
                     {
                         if (deadTags == null)
                         {
@@ -165,8 +182,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
                     }
                 }
 
-                nextToLastPurgeTick = lastPurgeTick;
-                lastPurgeTick = DateTime.Now;
+                FluidMoveBehavior.PurgeDeadStoryboards();
             }
 
             if (this.AppliesTo == FluidMoveScope.Self)
@@ -202,7 +218,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
             newTagData.Parent = VisualTreeHelper.GetParent(child) as FrameworkElement;
             newTagData.ParentRect = ExtendedVisualStateManager.GetLayoutRect(child);
             newTagData.Child = child;
-            newTagData.Timestamp = DateTime.Now;
+
 
             try
             {
@@ -298,7 +314,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
             tagData.AppRect = newTagData.AppRect;
             tagData.Parent = newTagData.Parent;
             tagData.Child = newTagData.Child;
-            tagData.Timestamp = newTagData.Timestamp;
+
         }
     }
 
@@ -415,7 +431,51 @@ namespace Microsoft.Xaml.Behaviors.Layout
         private static bool GetHasTransformWrapper(DependencyObject obj) { return (bool)obj.GetValue(hasTransformWrapperProperty); }
         private static void SetHasTransformWrapper(DependencyObject obj, bool value) { obj.SetValue(hasTransformWrapperProperty, value); }
 
-        private static Dictionary<object, Storyboard> transitionStoryboardDictionary = new Dictionary<object, Storyboard>();
+        internal static Dictionary<object, Storyboard> TransitionStoryboardDictionary = new Dictionary<object, Storyboard>();
+
+        /// <summary>
+        /// Removes entries from transitionStoryboardDictionary whose associated elements are no longer alive.
+        /// </summary>
+        internal static void PurgeDeadStoryboards()
+        {
+            List<object> deadTags = null;
+            foreach (var pair in TransitionStoryboardDictionary)
+            {
+                bool isDead = false;
+
+                // Element-type keys: the key is a FrameworkElement
+                if (pair.Key is FrameworkElement fe && !fe.IsLoaded)
+                {
+                    isDead = true;
+                }
+                // DataContext-type keys: cross-check TagDictionary to see if the element is still alive
+                else if (TagDictionary.TryGetValue(pair.Key, out var td) && !td.IsAlive)
+                {
+                    isDead = true;
+                }
+
+                if (isDead)
+                {
+                    if (deadTags == null)
+                    {
+                        deadTags = new List<object>();
+                    }
+                    deadTags.Add(pair.Key);
+                }
+            }
+            if (deadTags != null)
+            {
+                foreach (object tag in deadTags)
+                {
+                    Storyboard sb;
+                    if (TransitionStoryboardDictionary.TryGetValue(tag, out sb))
+                    {
+                        sb.Stop();
+                        TransitionStoryboardDictionary.Remove(tag);
+                    }
+                }
+            }
+        }
 
         protected override bool ShouldSkipInitialLayout
         {
@@ -437,6 +497,42 @@ namespace Microsoft.Xaml.Behaviors.Layout
                 {
                     child.SetBinding(initialIdentityTagProperty, new Binding(this.InitialTagPath));
                 }
+            }
+        }
+
+        protected override void OnDetaching()
+        {
+            CleanupStoryboards();
+            base.OnDetaching();
+        }
+
+        private void CleanupStoryboards()
+        {
+            if (this.AppliesTo == FluidMoveScope.Self)
+            {
+                CleanupTransitionStoryboard(this.AssociatedObject);
+            }
+            else
+            {
+                Panel panel = this.AssociatedObject as Panel;
+                if (panel != null)
+                {
+                    foreach (FrameworkElement child in panel.Children)
+                    {
+                        CleanupTransitionStoryboard(child);
+                    }
+                }
+            }
+        }
+
+        private static void CleanupTransitionStoryboard(FrameworkElement child)
+        {
+            object tag = GetIdentityTag(child) ?? child;
+            Storyboard storyboard;
+            if (TransitionStoryboardDictionary.TryGetValue(tag, out storyboard))
+            {
+                TransitionStoryboardDictionary.Remove(tag);
+                storyboard.Stop();
             }
         }
 
@@ -474,7 +570,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
                     previousRect = Rect.Empty;
                 }
 
-                tagData = new TagData() { ParentRect = Rect.Empty, AppRect = Rect.Empty, Parent = newTagData.Parent, Child = child, Timestamp = DateTime.Now, InitialTag = initialTag };
+                tagData = new TagData() { ParentRect = Rect.Empty, AppRect = Rect.Empty, Parent = newTagData.Parent, Child = child, InitialTag = initialTag };
                 TagDictionary.Add(tag, tagData);
             }
             else if (tagData.Parent != VisualTreeHelper.GetParent(child))
@@ -490,7 +586,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
             FrameworkElement originalChild = child;
 
             if ((!FluidMoveBehavior.IsEmptyRect(previousRect) && !FluidMoveBehavior.IsEmptyRect(newTagData.ParentRect)) && (!IsClose(previousRect.Left, newTagData.ParentRect.Left) || !IsClose(previousRect.Top, newTagData.ParentRect.Top)) ||
-                (child != tagData.Child && transitionStoryboardDictionary.ContainsKey(tag)))
+                (child != tagData.Child && TransitionStoryboardDictionary.ContainsKey(tag)))
             {
                 Rect currentRect = previousRect;
                 bool forceFloatAbove = false;
@@ -498,15 +594,17 @@ namespace Microsoft.Xaml.Behaviors.Layout
                 // If this element was animating before, append its current transform to the start position and kill the old animation.
                 // Note that in an overlay scenario, the animation is on the image in the overlay.
                 Storyboard oldTransitionStoryboard = null;
-                if (transitionStoryboardDictionary.TryGetValue(tag, out oldTransitionStoryboard))
+                if (TransitionStoryboardDictionary.TryGetValue(tag, out oldTransitionStoryboard))
                 {
-                    object tagOverlay = GetOverlay(tagData.Child);
-                    AdornerContainer adornerContainer = (AdornerContainer)tagOverlay;
+                    FrameworkElement previousChild = tagData.Child; // cache: may be null if GC'd
+
+                    object tagOverlay = previousChild != null ? GetOverlay(previousChild) : null;
+                    AdornerContainer adornerContainer = tagOverlay as AdornerContainer;
 
                     forceFloatAbove = (tagOverlay != null); // if floating before, we need to keep floating
-                    FrameworkElement elementWithTransform = tagData.Child;
+                    FrameworkElement elementWithTransform = previousChild;
 
-                    if (tagOverlay != null)
+                    if (adornerContainer != null)
                     {
                         Canvas overlayCanvas = adornerContainer.Child as Canvas;
                         if (overlayCanvas != null)
@@ -516,22 +614,26 @@ namespace Microsoft.Xaml.Behaviors.Layout
                     }
 
                     // if we're picking a specific starting point, don't append this transform
-                    if (!usingBeforeLoaded)
+                    if (!usingBeforeLoaded && elementWithTransform != null)
                     {
                         Transform transform = GetTransform(elementWithTransform);
                         currentRect = transform.TransformBounds(currentRect);
                     }
 
-                    transitionStoryboardDictionary.Remove(tag);
+                    TransitionStoryboardDictionary.Remove(tag);
                     oldTransitionStoryboard.Stop();
                     oldTransitionStoryboard = null;
-                    RemoveTransform(elementWithTransform);
 
-                    if (tagOverlay != null)
+                    if (elementWithTransform != null)
+                    {
+                        RemoveTransform(elementWithTransform);
+                    }
+
+                    if (tagOverlay != null && previousChild != null)
                     {
                         System.Windows.Documents.AdornerLayer.GetAdornerLayer(root).Remove(adornerContainer);
-                        TransferLocalValue(tagData.Child, FluidMoveBehavior.cacheDuringOverlayProperty, FrameworkElement.RenderTransformProperty);
-                        SetOverlay(tagData.Child, null);
+                        TransferLocalValue(previousChild, FluidMoveBehavior.cacheDuringOverlayProperty, FrameworkElement.RenderTransformProperty);
+                        SetOverlay(previousChild, null);
                     }
                 }
 
@@ -579,14 +681,14 @@ namespace Microsoft.Xaml.Behaviors.Layout
                 Storyboard transitionStoryboard = CreateTransitionStoryboard(child, usingBeforeLoaded, ref parentRect, ref currentRect);
 
                 // Put this storyboard in the running dictionary so we can detect reentrancy
-                transitionStoryboardDictionary.Add(tag, transitionStoryboard);
+                TransitionStoryboardDictionary.Add(tag, transitionStoryboard);
 
                 transitionStoryboard.Completed += delegate (object sender, EventArgs e)
                 {
                     Storyboard currentlyRunningStoryboard;
-                    if (transitionStoryboardDictionary.TryGetValue(tag, out currentlyRunningStoryboard) && currentlyRunningStoryboard == transitionStoryboard)
+                    if (TransitionStoryboardDictionary.TryGetValue(tag, out currentlyRunningStoryboard) && currentlyRunningStoryboard == transitionStoryboard)
                     {
-                        transitionStoryboardDictionary.Remove(tag);
+                        TransitionStoryboardDictionary.Remove(tag);
                         transitionStoryboard.Stop();
                         RemoveTransform(child);
                         child.InvalidateMeasure();
@@ -608,7 +710,7 @@ namespace Microsoft.Xaml.Behaviors.Layout
             tagData.AppRect = newTagData.AppRect;
             tagData.Parent = newTagData.Parent;
             tagData.Child = newTagData.Child;
-            tagData.Timestamp = newTagData.Timestamp;
+
         }
 
         private Storyboard CreateTransitionStoryboard(FrameworkElement child, bool usingBeforeLoaded, ref Rect layoutRect, ref Rect currentRect)

--- a/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
+++ b/src/Microsoft.Xaml.Behaviors/Layout/FluidMoveBehavior.cs
@@ -332,7 +332,6 @@ namespace Microsoft.Xaml.Behaviors.Layout
             tagData.AppRect = newTagData.AppRect;
             tagData.Parent = newTagData.Parent;
             tagData.Child = newTagData.Child;
-
         }
     }
 


### PR DESCRIPTION
### Description of Change ###

Addresses memory leaks in `FluidMoveBehavior`'s static `TagDictionary` and `TransitionStoryboardDictionary`. Previously, these dictionaries could hold strong references to `UIElements` and `Storyboards` even after the associated elements were removed from the visual tree or garbage collected, leading to memory accumulation over time.

This change introduces several improvements:
- The `TagData` structure now uses `WeakReference` for `Child` and `Parent` properties, allowing elements to be garbage collected when no other strong references exist.
- Implements a throttled purge mechanism in `OnLayoutUpdated` to regularly clean up `TagDictionary` entries whose associated child elements are no longer alive or are unloaded from the visual tree.
- Adds a `PurgeDeadStoryboards` method to proactively remove `Storyboard` entries from `TransitionStoryboardDictionary` if their corresponding `FrameworkElement` key is unloaded, if the associated `TagData`'s child is dead, or if the `TagDictionary` entry is missing.
- Incorporates eager removal of dead entries within `UpdateTagData` and `UpdateLayoutTransitionCore` to prevent re-adding already-collected elements.
- Ensures `Storyboards` are explicitly stopped and removed when a `FluidMoveBehavior` is detached or its tracked children are removed from the panel.
- Includes a new comprehensive unit test suite, `FluidMoveBehaviorTest.cs`, to validate the weak reference behavior, dictionary purging, and overall retention logic in various scenarios (element removal, reparenting).

**Note on ConditionalWeakTable**:  I considered replacing the static TagDictionary with ConditionalWeakTable to eliminate strong-key retention, but I don’t think it is a safe drop-in change here. While it works well for reference-identity keys like FrameworkElement and some DataContext cases, FluidMoveBehavior also supports TagPath, which means tags can be scalar values or strings and currently rely on normal Dictionary<object, ...> equality semantics (Equals / GetHashCode). ConditionalWeakTable uses reference identity, not value equality, so switching to it could break matching behavior for TagPath-based tags even when the values are logically equal. It also would not help much with transitionStoryboardDictionary, which still needs explicit enumeration and cleanup for stopping storyboards and tearing down overlay state. Because of that, I think ConditionalWeakTable is appealing for leak prevention but too risky here unless the behavior is redesigned around reference-identity-only tags.

### Bugs Fixed ###

- #38 - Fixes memory leaks in `FluidMoveBehavior` where static dictionaries retained references to UI elements and associated storyboards after they were no longer active.

### API Changes ###

Added:
 - `TagData.IsAlive` property (internal)
 - `FluidMoveBehaviorBase.ResetPurgeThrottle()` method (internal)
 - `FluidMoveBehavior.PurgeDeadStoryboards()` method (internal)
 - `FluidMoveBehavior.InjectStoryboardEntry()` method (internal)
 - `FluidMoveBehavior.StoryboardDictionaryContainsKey()` method (internal)
 - `FluidMoveBehavior.ClearStoryboardDictionary()` method (internal)

Changed:
 - `TagData.Child` and `TagData.Parent` now use `WeakReference` internally.
 - `FluidMoveBehavior.OnDetaching()` behavior to include storyboard cleanup.
 - Internal purge logic within `FluidMoveBehaviorBase.OnLayoutUpdated`.

Removed:
 - `TagData.Timestamp` property.

### Behavioral Changes ###

Applications using `FluidMoveBehavior` will experience improved memory management, particularly in scenarios involving dynamic UI where elements are frequently added, removed, or reparented. Elements and their associated `Storyboards` will now be correctly garbage collected, preventing a steady increase in memory footprint that could occur under previous implementations.

### PR Checklist ###

- [x] Has tests (new `FluidMoveBehaviorTest.cs` file provides extensive unit tests)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard