### PR TITLE
Sample: fixed path to cheer.mp3

### DIFF
--- a/samples/XAMLBehaviorsSample/XAMLBehaviorsSample/PlaySoundControl.xaml
+++ b/samples/XAMLBehaviorsSample/XAMLBehaviorsSample/PlaySoundControl.xaml
@@ -28,7 +28,7 @@
             <Button x:Name="button" Content="Click Me" HorizontalAlignment="Stretch" Grid.Row="1" Margin="0,10,0,10">
                 <Behaviors:Interaction.Triggers>
                     <Behaviors:EventTrigger EventName="Click" SourceObject="{Binding ElementName=button}">
-                        <Behaviors:PlaySoundAction Source="../../Assets/Cheer.mp3" Volume="1.0" />
+                        <Behaviors:PlaySoundAction Source="Assets/Cheer.mp3" Volume="1.0" />
                     </Behaviors:EventTrigger>
                 </Behaviors:Interaction.Triggers>
             </Button>
@@ -40,7 +40,7 @@
                     </TextBlock>
                     <TextBlock TextWrapping="Wrap" Margin="10,20,0,0" FontSize="15" Foreground="DeepPink" xml:space="preserve">&lt;Behaviors:Interaction.Triggers>
     &lt;Behaviors:EventTrigger EventName="Click" SourceObject="{Binding ElementName=button}">
-        &lt;Behaviors:PlaySoundAction Source="../../Assets/Cheer.mp3" />
+        &lt;Behaviors:PlaySoundAction Source="Assets/Cheer.mp3" />
     &lt;/Behaviors:EventTrigger>
 &lt;/Behaviors:Interaction.Triggers>
                     </TextBlock>


### PR DESCRIPTION
### Description of Change ###

In the PlaySoundControl.xaml sample, the relative path to the Cheer.mp3 file was incorrect. Instead of using the file in the executing directory of the debug folder, the path used a relative path that traversed upwards to the source file.

This has been fixed to use the Cheer.mp3 file that is copied into the corresponding debug folder.
