### PR TITLE
Fix recursive invocation in PropertyChangedTrigger.OnDetaching

### DIFF
--- a/src/Microsoft.Xaml.Behaviors/Core/PropertyChangedTrigger.cs
+++ b/src/Microsoft.Xaml.Behaviors/Core/PropertyChangedTrigger.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Xaml.Behaviors.Core
         protected override void OnDetaching()
         {
             this.PreviewInvoke -= this.OnPreviewInvoke;
-            this.OnDetaching();
+            base.OnDetaching();
         }
 
         void OnPreviewInvoke(object sender, PreviewInvokeEventArgs e)


### PR DESCRIPTION
This PR fixes a bug where `PropertyChangedTrigger.OnDetaching` was accidentally invoking itself recursively leading to a crash.
See #202 for more details.
