### PR TITLE
Use CFS package feed for pipeline NuGet restore (S360 3031535)

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -40,8 +40,6 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
-    settings:
-      networkIsolationPolicy: Permissive
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     sdl:
@@ -109,8 +107,13 @@ extends:
           displayName: Use NuGet 6.x
           inputs:
             versionSpec: 6.x
+        - task: NuGetAuthenticate@1
+          displayName: NuGet Authenticate
         - task: NuGetCommand@2
           displayName: NuGet restore
+          inputs:
+            selectOrConfig: config
+            nugetConfigPath: azure-pipelines/nuget.config
         - task: MicroBuildSigningPlugin@4
           inputs:
             signType: '$(SignType)'

--- a/azure-pipelines/nuget.config
+++ b/azure-pipelines/nuget.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- Pipeline-only feed: routes NuGet restore through the CFS-managed DevDiv_PublicPackages
+         mirror (which upstreams nuget.org) so official builds stay within 1ES network isolation.
+         Kept out of the repo root on purpose so external clones fall back to nuget.org and don't
+         need auth to this internal feed. Referenced explicitly via nugetConfigPath in build.yml.
+         See https://aka.ms/1es/netiso/CFS -->
+    <add key="DevDiv_PublicPackages" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/DevDiv_PublicPackages/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Route official-build package restore through the DevDiv_PublicPackages CFS-managed mirror feed (which upstreams nuget.org) so the build never contacts api.nuget.org directly, satisfying the [SFI-ES4.2.4] Network Isolation for CFS endpoints requirement.

The nuget.config lives under azure-pipelines/ (not the repo root) and is referenced explicitly via nugetConfigPath, so external clones of this public repo are unaffected and continue restoring from nuget.org without needing auth to the internal feed.


Copilot-Session: 5fd94a5f-353a-4ca3-a218-ecb66965d53a