### PR TITLE
Set networkIsolationPolicy in Azure pipeline

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -40,6 +40,8 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     sdl:


### PR DESCRIPTION
When this code builds in ADO, it's not supposed to use nuget.org as a feed, and I stopped using it with a recent PR. But the network isolation policy also needs to be set to really block it. I copied this from many other pipelines.