### PR TITLE
Add .NET 10 target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0

--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows;net10.0-windows</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <UseWPF>true</UseWPF>
     <OutputType>Library</OutputType>

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -126,14 +126,12 @@ extends:
             solution: src\BehaviorsSdk.sln
             msbuildArgs: /p:PublicRelease=$(Build.OfficialRelease) /p:NoWarn=1591 /p:DebugType=full /bl:$(Build.ArtifactStagingDirectory)\Logs\behaviors_sdk_wpf.binlog
             configuration: Release
-        - task: VSTest@2
+        - task: DotNetCoreCLI@2
           displayName: Run Unit Tests
           inputs:
-            testAssemblyVer2: |-
-              **\*UnitTests.dll
-              !**\*TestAdapter.dll
-              !**\obj\**
-            runInParallel: true
+            command: test
+            projects: Test\UnitTests\UnitTests.csproj
+            arguments: --configuration Release --no-build
         - task: VSBuild@1
           displayName: Build NuGet package
           inputs:

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -99,7 +99,12 @@ extends:
               **\bin\**\*
               **\obj\**\*
         - task: UseDotNet@2
-          displayName: Use .NET Core SDK
+          displayName: Use .NET 8 SDK
+          inputs:
+            version: 8.0.x
+            performMultiLevelLookup: true
+        - task: UseDotNet@2
+          displayName: Use .NET 10 SDK
           inputs:
             version: 10.0.x
             performMultiLevelLookup: true

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -43,12 +43,10 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
+      os: windows
     sdl:
-      sourceAnalysisPool:
-        name: AzurePipelines-EO
-        image: 1ESPT-Windows2022
-        os: windows
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       policheck:
         enabled: true
         exclusionsFile: $(System.DefaultWorkingDirectory)\azure-pipelines\PoliCheckExclusions.xml
@@ -61,7 +59,7 @@ extends:
         displayName: 'Build'
         cancelTimeoutInMinutes: 30
         pool:
-          name: VSEngSS-MicroBuild2022-1ES
+          name: VSEng-MicroBuildVSStable
         templateContext:
           mb:
             signing:
@@ -103,12 +101,12 @@ extends:
         - task: UseDotNet@2
           displayName: Use .NET Core SDK
           inputs:
-            version: 9.0.x
+            version: 10.0.x
             performMultiLevelLookup: true
         - task: NuGetToolInstaller@1
-          displayName: Use NuGet 6.x
+          displayName: Use NuGet 7.x
           inputs:
-            versionSpec: 6.x
+            versionSpec: 7.x
         - task: NuGetAuthenticate@1
           displayName: NuGet Authenticate
         - task: NuGetCommand@2
@@ -157,6 +155,7 @@ extends:
             SymbolsProject: VS
             SymbolsAgentPath: $(Pipeline.Workspace)\Symbols
             SubmitToInternet: false
+            SuppressSymwebOnlyWarning: true
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         - task: CopyFiles@2

--- a/samples/XAMLBehaviorsSample/XAMLBehaviorsSample/XAMLBehaviorsSample.csproj
+++ b/samples/XAMLBehaviorsSample/XAMLBehaviorsSample/XAMLBehaviorsSample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <AssemblyName>XAMLBehaviorsSample</AssemblyName>

--- a/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
+++ b/src/Microsoft.Xaml.Behaviors/Microsoft.Xaml.Behaviors.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows;net10.0-windows</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectToProjectAssets</TargetsForTfmSpecificBuildOutput>
     <OutputType>Library</OutputType>
     <PackageId>Microsoft.Xaml.Behaviors.Wpf</PackageId>


### PR DESCRIPTION
Build .NET 8 and .NET 10 assets in the same NuGet package, and update CI to use the .NET 10 SDK.
Note that before now, the unit tests were actually broken even though the Run Unit Tests task was passing. This change installs .NET 8 in addition to .NET 10 so that all tests can run (they all pass).